### PR TITLE
NXDOC-2470: Fix URL of Arender install doc

### DIFF
--- a/src/nxdoc/nuxeo-add-ons/nuxeo-enhanced-viewer.md
+++ b/src/nxdoc/nuxeo-add-ons/nuxeo-enhanced-viewer.md
@@ -398,7 +398,7 @@ In order to make the integration work on modern browsers, Nuxeo and NEV 10.3.x s
 
 ### ARender Configuration
 
-Nuxeo Enhanced Viewer involves installing the ARender services. You can install the ARender services using Kubernetes and Helm 3 by following the [ARender Documentation](https://arender.io/documentation/install/kubernetes/).
+Nuxeo Enhanced Viewer involves installing the ARender services. You can install the ARender services using Kubernetes and Helm 3 by following the [ARender Documentation](https://docs.arender.io/install/kubernetes/).
 
 {{#> callout type='warning' heading='Private services'}}
 You should contact your Nuxeo Administrator or your Nuxeo sales representative to get access to these services.


### PR DESCRIPTION
Should also be on master, but looks like I can't do this without creating a conflict (used the edit on github button in our doc)