### PR TITLE
NXDOC-2956: document Audit Router and Blue/Green Audit migration

### DIFF
--- a/assets/nxdoc/audit/architecture-diagram.png
+++ b/assets/nxdoc/audit/architecture-diagram.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b26bc78005ead287649812a5181a3a13847ff8587ed88e314ed9fe1b6d1de440
+size 50415

--- a/src/nxdoc/nuxeo-server/data-store/data-modeling/audit.md
+++ b/src/nxdoc/nuxeo-server/data-store/data-modeling/audit.md
@@ -1,9 +1,9 @@
 ---
 title: Audit
-description: The Audit Service is mainly a data store service. It defines a data record structure that will be used for storing audit information.
+description: The Audit Service stores audit log entries derived from Nuxeo events into one or more Audit Backends.
 review:
     comment: ''
-    date: '2017-12-14'
+    date: '2026-05-07'
     status: ok
 labels:
     - lts2016-ok
@@ -143,11 +143,56 @@ Service. Then the Audit Service filters and converts them into log entries. The
 Nuxeo documents and events can have a lot of custom properties, so if you want
 to log some specific events or document properties, the
 [Extended Info](#extendedinfo) allows for a Key/Value type storage that will be
-associated to the main `LogEntry` record. These informations are extracted from
-the event message using and EL (Expression Language) expression and stored into
+associated to the main `LogEntry` record. This information is extracted from
+the event message using an EL (Expression Language) expression and stored into
 a map.
 
-### Audit Back-ends
+Since LTS 2025 the Audit Service has been redesigned to support **multiple
+backends in parallel** through the
+[`AuditRouter`]({{page page='audit-router'}}). The high-level pipeline is:
+
+```
+Nuxeo Event Service
+        │
+        ▼
+StreamAuditEventListener (sync, priority 500)
+        │  AuditRouter computes LogEntry from event
+        ▼
+audit/audit Nuxeo Stream
+        │
+        ▼
+audit/writer computation (StreamAuditWriter)
+        │  AuditRouter.routeToBackend(LogEntry)
+        ▼
+        ├──► Audit Backend "default"
+        ├──► Audit Backend "secondary"
+        └──► …
+```
+
+### Services
+
+| Service                                              | Purpose                                                          |
+|------------------------------------------------------|------------------------------------------------------------------|
+| `org.nuxeo.audit.service.AuditService`               | Entry point — exposes the configured backends and the router.     |
+| `org.nuxeo.audit.service.AuditBackend`               | Backend SPI — read, write and query log entries.                  |
+| `org.nuxeo.audit.service.AuditRouter`                | Internal service computing and routing log entries to the configured backends. |
+
+The legacy `AuditReader`, `AuditLogger` and `AuditAdmin` services from the
+`org.nuxeo.ecm.platform.audit.api` package are still available and proxy to the
+default backend. They are deprecated and will be removed in a future release —
+new code should target `AuditService` and `AuditBackend` directly. To get the
+default backend:
+
+```java
+AuditService auditService = Framework.getService(AuditService.class);
+AuditBackend backend = auditService.getAuditBackend("default");
+```
+
+See the
+[How to Upgrade Nuxeo Audit Service]({{page page='how-to-upgrade-audit-service'}})
+page for the full migration guide.
+
+### {{> anchor 'audit-back-ends'}}Audit Backends
 
 Since LTS 2025, you have to explicitly choose a backend implementation from the
 following implementations listed below:
@@ -165,27 +210,47 @@ Each child page lists the configuration properties exposed by the package as
 `nuxeo.audit.backend.default.<implementation>.*` so you can override them in
 `nuxeo.conf`.
 
+### Audit Router
+
+The [Audit Router]({{page page='audit-router'}}) (since 2025.16) replaces the
+legacy `event` extension point with a richer `routes` extension point:
+
+* A route binds a **backend** to a set of **events** and **predicates**.
+* Several routes can match the same entry, so the same event can be written to multiple backends in parallel.
+* The legacy `event` extension point still works and is automatically merged into the implicit `default` route.
+
+The [Audit Router]({{page page='audit-router'}}) child page contains the full
+extension-point reference and worked examples (route a custom business event to
+a secondary backend, filter by category, etc.).
+
 ## Querying the Audit Data Store
 
-The Service API is composed of three services:
+The `AuditService` is the entry point to read audit data. From it you get an
+`AuditBackend` that exposes the read API on a specific backend (the default
+one in most cases).
 
-* `AuditReader`: service for reading data from the audit logs. [More details](http://explorer.nuxeo.com/nuxeo/site/distribution/latest/viewService/org.nuxeo.ecm.platform.audit.api.AuditReader).
-* `AuditLogger`: service for adding data into the audit logs. [More details](http://explorer.nuxeo.com/nuxeo/site/distribution/latest/viewService/org.nuxeo.ecm.platform.audit.api.AuditLogger).
-* `AuditAdmin`: service for administrating the Audit Service.
-
-A set of methods allows the user to do common queries quite easily like getting
-all the log entries for a document, getting a specific log by its id, etc.
+A set of methods allows you to do common queries quite easily like getting all
+the log entries for a document, getting a specific log by its id, etc.
 
 ```java
-AuditReader reader = Framework.getService(AuditReader.class);
+AuditService auditService = Framework.getService(AuditService.class);
+AuditBackend backend = auditService.getAuditBackend("default");
 
 // Getting of the logs for the document 'doc' in 'myRepository'
-List<LogEntry> logEntries = reader.getLogEntriesFor(doc.getId(), 'myRepository');
+List<LogEntry> logEntries = backend.getLogEntriesFor(doc.getId(), "myRepository");
 
 // Same method but with a query builder
 AuditQueryBuilder builder = new AuditQueryBuilder();
-builder.predicates(Predicates.eq("docUUID", doc.getId()), Predicates.eq("repositoryId", 'myRepository'));
-List<LogEntry> logEntriesFiltered = reader.queryLogs(builder);
+builder.predicates(Predicates.eq(LogEntryConstants.LOG_DOC_UUID, doc.getId()),
+                   Predicates.eq(LogEntryConstants.LOG_REPOSITORY_ID, "myRepository"));
+List<LogEntry> logEntriesFiltered = backend.queryLogs(builder);
+```
+
+To target another backend, just ask the `AuditService` for it:
+
+```java
+AuditBackend secondary = auditService.getAuditBackend("secondary");
+List<LogEntry> entries = secondary.queryLogs(builder);
 ```
 
 There are two PageProviders that can be used for querying the Audit data store:
@@ -193,30 +258,51 @@ There are two PageProviders that can be used for querying the Audit data store:
 * `AuditPageProvider`: allows to generate simple queries against Audit entries.
 * `DocumentHistoryReader`: allows to compute history for a given document.
 
-    [More details on the explorer](http://explorer.nuxeo.com/nuxeo/site/latest/viewContribution/org.nuxeo.ecm.platform.audit.PageProviderservice.contrib--providers).
+    [More details on the explorer](https://explorer.nuxeo.com/nuxeo/site/distribution/latest/viewContribution/org.nuxeo.audit.PageProviderService.contrib--providers).
+
+By default both PageProviders query the default backend. They support targeting
+a specific backend through the `backend` PageProvider property.
 
 A schema has been defined for basic Audit search: `basicauditsearch.xsd`. This
-schema is helpful for building a PageProvider feeding a ContentView with data
-from the Audit data store. An object `BasicAuditSearch` could be used to define
-queries on the audit data store.
+schema is helpful for building a PageProvider querying the Audit data store. An
+object `BasicAuditSearch` could be used to define queries on the audit data
+store.
 
 ## Extending the Audit Service
 
-There a few extension points used to contribute to the Audit Service:
+The Audit Service exposes the following extension points on the
+`org.nuxeo.audit.service.AuditComponent` component:
 
-* `event`
-* `extendedInfo`
-* `adapter`
-* `listener`
+| Extension Point  | Purpose                                                                                                                |
+|------------------|------------------------------------------------------------------------------------------------------------------------|
+| `routes`         | Bind a backend to a set of events and predicates. **Since 2025.16.**                                                   |
+| `event`          | Register an auditable event. **Deprecated since 2025.16** — use `routes` instead. Backward-compatible.                  |
+| `extendedInfo`   | Extract custom values from the event context using EL and store them on the log entry.                                  |
+| `adapter`        | Register an adapter exposed to EL expressions of `extendedInfo`.                                                        |
+| `backendFactory` | Register an `AuditBackend` implementation. Contributed by the audit Marketplace Packages, rarely used by integrations.  |
 
-Two others extension points can be used to configure the datastorage for Audit:
+### Routes — Recommended Since 2025.16
 
-* `queues`
-* `hibernate` **&dash; for the legacy SQL back-end only**
+The `routes` extension point is the modern way to declare what is audited and
+where it is stored. A minimal route registers an event and writes it to the
+default backend:
 
-### Event
+```xml
+<extension target="org.nuxeo.audit.service.AuditComponent" point="routes">
+  <route name="documentLifecycle">
+    <backend name="default" />
+    <event name="documentCreated" />
+    <event name="documentModified" />
+  </route>
+</extension>
+```
 
-Those default auditable events match the Nuxeo core base events:
+See the [Audit Router]({{page page='audit-router'}}) child page for the full
+reference (predicates, route inheritance with `copy`, routing semantics, …) and
+worked examples.
+
+The Nuxeo Platform contributes a `default` route which holds the auditable
+events matching the Nuxeo core base events:
 
 * `documentCreated`
 * `documentCreatedByCopy`
@@ -239,37 +325,28 @@ Those default auditable events match the Nuxeo core base events:
 
 {{#> callout type='info'  heading='Full List'}}
 The full list of audit events used in the platform can be found
-[here](https://explorer.nuxeo.com/nuxeo/site/distribution/latest/viewExtensionPoint/org.nuxeo.ecm.platform.audit.service.NXAuditEventsService--event).
+[here](https://explorer.nuxeo.com/nuxeo/site/distribution/latest/viewExtensionPoint/org.nuxeo.audit.service.AuditComponent--routes).
 {{/callout}}
 
 If you are sending new Nuxeo core events and want them to be audited, you have
-to extend the `event` extension point. Here is an example of a contribution to
-this extension point:
+to contribute them to the `routes` extension point. Here is an example of a
+contribution adding a custom event to the `default` route:
 
 ```xml
-<extension target="org.nuxeo.ecm.platform.audit.service.NXAuditEventsService" point="event">
-	<event name="documentCreated" />
-    <event name="documentCreatedByCopy" />
-    <event name="documentDuplicated" />
-    <event name="documentMoved" />
-    <event name="documentRemoved" />
-    <event name="documentModified" />
-    <event name="documentLocked" />
-    <event name="documentUnlocked" />
-    <event name="documentSecurityUpdated" />
-    <event name="lifecycle_transition_event" />
-    <event name="loginSuccess" />
-    <event name="loginFailed" />
-    <event name="logout" />
-    <event name="documentCheckedIn" />
-    <event name="versionRemoved" />
-    <event name="documentProxyPublished" />
-    <event name="sectionContentPublished" />
-    <event name="documentRestored" />
+<extension target="org.nuxeo.audit.service.AuditComponent" point="routes">
+  <route name="default">
+    <event name="myCustomEvent" />
+  </route>
 </extension>
 ```
 
-[More details on the explorer.](http://explorer.nuxeo.com/nuxeo/site/distribution/latest/viewExtensionPoint/org.nuxeo.ecm.platform.audit.service.NXAuditEventsService--event)
+[More details on the explorer.](https://explorer.nuxeo.com/nuxeo/site/distribution/latest/viewExtensionPoint/org.nuxeo.audit.service.AuditComponent--routes)
+
+### Event — Deprecated Since 2025.16
+
+The `event` extension point keeps registering auditable events on the implicit
+`default` route. It is the legacy way of declaring audited events and
+remains supported for backward compatibility.
 
 ### Extended Info{{> anchor 'extendedinfo'}}
 
@@ -292,7 +369,7 @@ the `extendedInfo` extension point. Here is an example of a contribution to this
 extension point
 
 ```xml
-<extension point="extendedInfo" target="org.nuxeo.ecm.platform.audit.service.NXAuditEventsService">
+<extension target="org.nuxeo.audit.service.AuditComponent" point="extendedInfo">
     <extendedInfo expression="${source.dublincore.title}" key="title" />
     <extendedInfo expression="${message.cacheKey}" key="key" />
     <extendedInfo expression="${principal.name}" key="user" />
@@ -302,8 +379,7 @@ extension point
 You can also extend the audit info per event name:
 
 ```xml
-<extension target="org.nuxeo.ecm.platform.audit.service.NXAuditEventsService"
-    point="event">
+<extension target="org.nuxeo.audit.service.AuditComponent" point="event">
     <event name="afterWorkflowStarted">
       <extendedInfos>
         <extendedInfo expression="${message.properties.modelId}" key="modelId" />
@@ -316,67 +392,58 @@ You can also extend the audit info per event name:
 ```
 
 For instance, the above contribution will add `modelId`, `modelName`,
-`worklowInitiator`, `workflowVarriables` to the `extendedInfo` only for the
+`workflowInitiator`, `workflowVariables` to the `extendedInfo` only for the
 `afterWorkflowStarted` event.
 
-When the extension point is contributed, the data are stored into the
-`audit.elasticsearch.indexName` index for the Elasticsearch back-end, into the
-`NXP_LOGS_EXTINFO` and `NXP_LOGS_MAPEXTINFOS` tables for the legacy SQL back-end
-and into the `audit` collection in the `audit` database for the MongoDB
-back-end.
+{{#> callout type='info' heading='Recommended since 2025.16'}}
+Since the introduction of the [Audit Router]({{page page='audit-router'}}),
+per-event `extendedInfo` entries have to be declared directly on the
+`extendedInfo` extension point with an `event` attribute, for instance:
 
-[More details on the explorer.](http://explorer.nuxeo.com/nuxeo/site/distribution/latest/viewExtensionPoint/org.nuxeo.ecm.platform.audit.service.NXAuditEventsService--extendedInfo)
+```xml
+<extension target="org.nuxeo.audit.service.AuditComponent" point="extendedInfo">
+    <extendedInfo event="afterWorkflowStarted" expression="${message.properties.modelId}" key="modelId" />
+</extension>
+```
+
+This is the recommended form. The legacy form nesting `<extendedInfo>` inside
+`<event>` is kept for backward compatibility but will be removed in the future.
+{{/callout}}
+
+[More details on the explorer.](https://explorer.nuxeo.com/nuxeo/site/distribution/latest/viewExtensionPoint/org.nuxeo.audit.service.AuditComponent--extendedInfo)
 
 ### Adapter
 
 The contribution to the `adapter` extension point of the
-`org.nuxeo.ecm.platform.audit.service.NXAuditEventsService` component allows to
-define the adapter that will be injected in the EL context. Here is an example
-of a contribution to this extension point.
+`org.nuxeo.audit.service.AuditComponent` component allows to define the adapter
+that will be injected in the EL context. Here is an example of a contribution to
+this extension point.
 
 ```xml
-<extension target="org.nuxeo.ecm.platform.audit.service.NXAuditEventsService" point="adapter">
+<extension target="org.nuxeo.audit.service.AuditComponent" point="adapter">
     <adapter name="myadapter" class="org.nuxeo.ecm.core.api.facet.VersioningDocument"/>
 </extension>
 ```
 
-[More details on the explorer.](http://explorer.nuxeo.com/nuxeo/site/distribution/latest/viewExtensionPoint/org.nuxeo.ecm.platform.audit.service.NXAuditEventsService--adapter)
+[More details on the explorer.](https://explorer.nuxeo.com/nuxeo/site/distribution/latest/viewExtensionPoint/org.nuxeo.audit.service.AuditComponent--adapter)
 
-### Listener
+### Live Ingestion — Stream Audit Writer
 
-A post commit asynchronous listener is defined and an Event Bundle, which is an
-ordered set of events raised during a user operation, is pushed into the Audit
-log. Here is an example of a contribution to the `listener` extension point.
+The audit ingestion pipeline is built on top of
+[Nuxeo Stream]({{page page='nuxeo-stream'}}). A synchronous event listener
+(`StreamAuditEventListener`) serializes each audited event as a `LogEntry` and
+appends it to the `audit/audit` stream. A computation (`auditWriter`) consumes
+the stream and delegates the actual write to the
+[`AuditRouter`]({{page page='audit-router'}}).
 
-```xml
-<extension target="org.nuxeo.ecm.core.event.EventServiceComponent" point="listener">
-	<listener name="auditLoggerListener" async="true" postCommit="true"
-	class="org.nuxeo.ecm.platform.audit.listener.AuditEventLogger" />
-</extension>
-```
+This replaces the historical post-commit `auditLoggerListener` and the dedicated
+Works `audit` queue: there is **no** `queue` extension point to configure for
+the Audit Service anymore.
 
-[More details on the explorer.](http://explorer.nuxeo.com/nuxeo/site/distribution/latest/viewContribution/org.nuxeo.ecm.platform.audit.service.NXAuditEventsService--listener)
+## Learn More
 
-Note that since 9.3 by default this listener is overridden by the
-[Nuxeo Stream audit writer]({{page page='nuxeo-stream'}}).
-
-### Queues
-
-It is also possible to configure queues used by the Audit Service. Each queue is
-using a separate queue and a single thread for logging. The extension point used
-to define the queues' parameters is `queue` for the
-`org.nuxeo.ecm.core.work.service` target.
-
-```xml
-<extension target="org.nuxeo.ecm.core.work.service" point="queues">
-  <queue id="audit">
-    <name>Audit queue</name>
-    <maxThreads>1</maxThreads>
-    <category>auditLoggerListener</category>
-    <!-- clear completed work instances older than 5 min -->
-    <clearCompletedAfterSeconds>300</clearCompletedAfterSeconds>
-  </queue>
-</extension>
-```
-
-[More details on the explorer.](http://explorer.nuxeo.com/nuxeo/site/distribution/latest/viewExtensionPoint/org.nuxeo.ecm.core.work.service--queues)
+* [Audit Router]({{page page='audit-router'}})
+* [Copy an Audit Backend]({{page page='copy-audit-backend'}})
+* [Audit Endpoint]({{page space='rest-api' version='1' page='audit-endpoint'}})
+* [How to Upgrade Nuxeo Audit Service]({{page page='how-to-upgrade-audit-service'}})
+* [Backing Up and Restoring the Audit Index]({{page page='backup-and-restore'}}#backingupandrestoringtheauditelasticsearchindex)

--- a/src/nxdoc/nuxeo-server/data-store/data-modeling/audit.md
+++ b/src/nxdoc/nuxeo-server/data-store/data-modeling/audit.md
@@ -112,7 +112,12 @@ history:
         version: '1'
 ---
 
-The Audit Service is used for logging and retrieving audit data into a data store. The service can be accessed directly with the Java API for reading or writing audit entries but the main source for Audit entries is the Nuxeo event bus: the Audit Service listens to all events that may occur on the platform (document creation, user logging in, workflow started ...) and according to the configuration an Audit record will be created.
+The Audit Service is used for logging and retrieving audit data into a data
+store. The service can be accessed directly with the Java API for reading or
+writing audit entries but the main source for Audit entries is the Nuxeo event
+bus: the Audit Service listens to all events that may occur on the platform
+(document creation, user logging in, workflow started ...) and according to the
+configuration an Audit record will be created.
 
 {{#> callout type='info'  heading='Hyland University'}}
 Watch the related course on Hyland University:</br>
@@ -127,15 +132,25 @@ Watch the related course on Hyland University:</br>
 
 ## Architecture
 
-The Audit Service is mainly a data store service. It defines a data record structure that will be used for storing audit information.
+The Audit Service is mainly a data store service. It defines a data record
+structure that will be used for storing audit information.
 
-The data record structure is defined in Java by the `LogEntry` and `ExtendedInfo` Java classes. The Audit Service receives events from the Event Service. Then the Audit Service filters and converts them into log entries. The `LogEntry` class is mainly obtained from a `DocumentEventContext`.
+The data record structure is defined in Java by the `LogEntry` and
+`ExtendedInfo` Java classes. The Audit Service receives events from the Event
+Service. Then the Audit Service filters and converts them into log entries. The
+`LogEntry` class is mainly obtained from a `DocumentEventContext`.
 
-Nuxeo documents and events can have a lot of custom properties, so if you want to log some specific events or document properties, the [Extended Info](#extendedinfo) allows for a Key/Value type storage that will be associated to the main `LogEntry` record. These informations are extracted from the event message using and EL (Expression Language) expression and stored into a map.
+Nuxeo documents and events can have a lot of custom properties, so if you want
+to log some specific events or document properties, the
+[Extended Info](#extendedinfo) allows for a Key/Value type storage that will be
+associated to the main `LogEntry` record. These informations are extracted from
+the event message using and EL (Expression Language) expression and stored into
+a map.
 
 ### Audit Back-ends
 
-Since LTS 2025, you have to explicitly choose a backend implementation from the following implementations listed below:
+Since LTS 2025, you have to explicitly choose a backend implementation from the
+following implementations listed below:
 
 | Backend                                  | Marketplace Package             |
 |------------------------------------------|---------------------------------|
@@ -150,44 +165,61 @@ More information below.
 
 #### OpenSearch 1.x / Elasticsearch 7.x - 8.x Back-end
 
-By installing the `nuxeo-audit-opensearch1` package, you have the previous default behavior of storing audit into an OpenSearch 1.x / Elasticsearch 7.x - 8.x cluster.
+By installing the `nuxeo-audit-opensearch1` package, you have the previous
+default behavior of storing audit into an OpenSearch 1.x / Elasticsearch 7.x -
+8.x cluster.
 
-The audit entries are stored in an OpenSearch index named by the `nuxeo.audit.backend.default.opensearch1.index.name` property (previously `audit.elasticsearch.indexName`) in `nuxeo.conf`.
+The audit entries are stored in an OpenSearch index named by the
+`nuxeo.audit.backend.default.opensearch1.index.name` property (previously
+`audit.elasticsearch.indexName`) in `nuxeo.conf`.
 
 {{#> callout type='warning' }}
-Make sure you read the [Backing Up and Restoring the Audit Elasticsearch Index]({{page page='backup-and-restore'}}#backingupandrestoringtheauditelasticsearchindex) section.
+Make sure you read the
+[Backing Up and Restoring the Audit Elasticsearch Index]({{page page='backup-and-restore'}}#backingupandrestoringtheauditelasticsearchindex)
+section.
 {{/callout}}
 
-Fore more information about the global Elasticsearch setup, see [Elasticsearch Setup]({{page page='elasticsearch-setup'}}).
+Fore more information about the global Elasticsearch setup, see
+[Elasticsearch Setup]({{page page='elasticsearch-setup'}}).
 
 #### OpenSearch 2.x Back-end
 
-To use OpenSearch 2.x back-end, you have to install the `nuxeo-audit-opensearch2` package.
+To use OpenSearch 2.x back-end, you have to install the
+`nuxeo-audit-opensearch2` package.
 
-The entries are stored in the `nuxeo-audit` index by default.
-You can configure it by setting the `nuxeo.audit.backend.default.opensearch2.index.name` property in your `nuxeo.conf`.
+The entries are stored in the `nuxeo-audit` index by default. You can configure
+it by setting the `nuxeo.audit.backend.default.opensearch2.index.name` property
+in your `nuxeo.conf`.
 
 #### Elasticsearch 9.x Back-end
 
-To use Elasticsearch 9.x back-end, you have to install the `nuxeo-audit-elasticsearch9` package.
+To use Elasticsearch 9.x back-end, you have to install the
+`nuxeo-audit-elasticsearch9` package.
 
-The entries are stored in the `nuxeo-audit` index by default.
-You can configure it by setting the `nuxeo.audit.backend.default.elasticsearch9.index.name` property in your `nuxeo.conf`.
+The entries are stored in the `nuxeo-audit` index by default. You can configure
+it by setting the `nuxeo.audit.backend.default.elasticsearch9.index.name`
+property in your `nuxeo.conf`.
 
 #### MongoDB Back-end
 
 To use MongoDB back-end, you have to install the `nuxeo-audit-mongodb` package.
 
-The entries are stored in the `audit` collection by default.
-You can configure it by setting the `nuxeo.mongodb.audit.collection.name` property in your `nuxeo.conf`.
+The entries are stored in the `audit` collection by default. You can configure
+it by setting the `nuxeo.mongodb.audit.collection.name` property in your
+`nuxeo.conf`.
 
 #### Legacy SQL Back-end
 
-To use the legacy SQL back-end, you have to install the `nuxeo-audit-sql` package.
+To use the legacy SQL back-end, you have to install the `nuxeo-audit-sql`
+package.
 
-The `LogEntry` and `ExtendedInfo` Java classes are mapped onto the datastore using JPA (Java Persistence API) annotations.
+The `LogEntry` and `ExtendedInfo` Java classes are mapped onto the datastore
+using JPA (Java Persistence API) annotations.
 
-There are three tables used by the Audit Service: `NXP_LOGS`, `NXP_LOGS_EXTINFO` and `NXP_LOGS_MAPEXTINFOS`. `NXP_LOGS` is the main table, it is used most of the time. The two others are used only when the `extendedInfo` extension point is defined.
+There are three tables used by the Audit Service: `NXP_LOGS`, `NXP_LOGS_EXTINFO`
+and `NXP_LOGS_MAPEXTINFOS`. `NXP_LOGS` is the main table, it is used most of the
+time. The two others are used only when the `extendedInfo` extension point is
+defined.
 
 ![]({{file name='diagram.png'}} ?w=600,border=true)
 
@@ -199,7 +231,8 @@ The Service API is composed of three services:
 * `AuditLogger`: service for adding data into the audit logs. [More details](http://explorer.nuxeo.com/nuxeo/site/distribution/latest/viewService/org.nuxeo.ecm.platform.audit.api.AuditLogger).
 * `AuditAdmin`: service for administrating the Audit Service.
 
-A set of methods allows the user to do common queries quite easily like getting all the log entries for a document, getting a specific log by its id, etc.
+A set of methods allows the user to do common queries quite easily like getting
+all the log entries for a document, getting a specific log by its id, etc.
 
 ```java
 AuditReader reader = Framework.getService(AuditReader.class);
@@ -213,7 +246,9 @@ builder.predicates(Predicates.eq("docUUID", doc.getId()), Predicates.eq("reposit
 List<LogEntry> logEntriesFiltered = reader.queryLogs(builder);
 ```
 
-You can perform some simple queries using the Elasticsearch API, here is an example of getting all the logs of the category 'MyExport' ordered by the date of the event:
+You can perform some simple queries using the Elasticsearch API, here is an
+example of getting all the logs of the category 'MyExport' ordered by the date
+of the event:
 
 ```java
 List<LogEntry> entries = new ArrayList<>();
@@ -234,7 +269,8 @@ for (SearchHit hit : searchResponse.getHits()) {
 }
 ```
 
-When using the legacy SQL back-end, you can use `AuditReader` to do simple queries using the JPA Query language:
+When using the legacy SQL back-end, you can use `AuditReader` to do simple
+queries using the JPA Query language:
 
 ```java
 StringBuffer query = new StringBuffer("from LogEntry log where ");
@@ -252,7 +288,10 @@ There are two PageProviders that can be used for querying the Audit data store:
 
     [More details on the explorer](http://explorer.nuxeo.com/nuxeo/site/latest/viewContribution/org.nuxeo.ecm.platform.audit.PageProviderservice.contrib--providers).
 
-A schema has been defined for basic Audit search: `basicauditsearch.xsd`. This schema is helpful for building a PageProvider feeding a ContentView with data from the Audit data store. An object `BasicAuditSearch` could be used to define queries on the audit data store.
+A schema has been defined for basic Audit search: `basicauditsearch.xsd`. This
+schema is helpful for building a PageProvider feeding a ContentView with data
+from the Audit data store. An object `BasicAuditSearch` could be used to define
+queries on the audit data store.
 
 ## Extending the Audit Service
 
@@ -292,10 +331,13 @@ Those default auditable events match the Nuxeo core base events:
 * `documentRestored`
 
 {{#> callout type='info'  heading='Full List'}}
-The full list of audit events used in the platform can be found [here](https://explorer.nuxeo.com/nuxeo/site/distribution/latest/viewExtensionPoint/org.nuxeo.ecm.platform.audit.service.NXAuditEventsService--event).
+The full list of audit events used in the platform can be found
+[here](https://explorer.nuxeo.com/nuxeo/site/distribution/latest/viewExtensionPoint/org.nuxeo.ecm.platform.audit.service.NXAuditEventsService--event).
 {{/callout}}
 
-If you are sending new Nuxeo core events and want them to be audited, you have to extend the `event` extension point. Here is an example of a contribution to this extension point:
+If you are sending new Nuxeo core events and want them to be audited, you have
+to extend the `event` extension point. Here is an example of a contribution to
+this extension point:
 
 ```xml
 <extension target="org.nuxeo.ecm.platform.audit.service.NXAuditEventsService" point="event">
@@ -324,17 +366,23 @@ If you are sending new Nuxeo core events and want them to be audited, you have t
 
 ### Extended Info{{> anchor 'extendedinfo'}}
 
-This service is used to evaluate EL expressions using a document as context and registering results into a Map indexed by names.
+This service is used to evaluate EL expressions using a document as context and
+registering results into a Map indexed by names.
 
-Just after converting a received `DocumentEventContext` instance into the corresponding `LogEntry` instance, the Audit Service allows you to extract information from the handling context and to store them.
+Just after converting a received `DocumentEventContext` instance into the
+corresponding `LogEntry` instance, the Audit Service allows you to extract
+information from the handling context and to store them.
 
-To do this, you have to define an EL expression and associate it with a key. You can access to the following variables:
+To do this, you have to define an EL expression and associate it with a key. You
+can access to the following variables:
 
 * `message`: Document event context describing the event.
 * `source`: Document from which the event is from.
 * `principal`: Identity of the event owner.
 
-If you want to contribute to the extended info of the service, you have to use the `extendedInfo` extension point. Here is an example of a contribution to this extension point
+If you want to contribute to the extended info of the service, you have to use
+the `extendedInfo` extension point. Here is an example of a contribution to this
+extension point
 
 ```xml
 <extension point="extendedInfo" target="org.nuxeo.ecm.platform.audit.service.NXAuditEventsService">
@@ -360,15 +408,24 @@ You can also extend the audit info per event name:
 </extension>
 ```
 
-For instance, the above contribution will add `modelId`, `modelName`, `worklowInitiator`, `workflowVarriables` to the `extendedInfo` only for the `afterWorkflowStarted` event.
+For instance, the above contribution will add `modelId`, `modelName`,
+`worklowInitiator`, `workflowVarriables` to the `extendedInfo` only for the
+`afterWorkflowStarted` event.
 
-When the extension point is contributed, the data are stored into the `audit.elasticsearch.indexName` index for the Elasticsearch back-end, into the `NXP_LOGS_EXTINFO` and `NXP_LOGS_MAPEXTINFOS` tables for the legacy SQL back-end and into the `audit` collection in the `audit` database for the MongoDB back-end.
+When the extension point is contributed, the data are stored into the
+`audit.elasticsearch.indexName` index for the Elasticsearch back-end, into the
+`NXP_LOGS_EXTINFO` and `NXP_LOGS_MAPEXTINFOS` tables for the legacy SQL back-end
+and into the `audit` collection in the `audit` database for the MongoDB
+back-end.
 
 [More details on the explorer.](http://explorer.nuxeo.com/nuxeo/site/distribution/latest/viewExtensionPoint/org.nuxeo.ecm.platform.audit.service.NXAuditEventsService--extendedInfo)
 
 ### Adapter
 
-The contribution to the `adapter` extension point of the `org.nuxeo.ecm.platform.audit.service.NXAuditEventsService` component allows to define the adapter that will be injected in the EL context. Here is an example of a contribution to this extension point.
+The contribution to the `adapter` extension point of the
+`org.nuxeo.ecm.platform.audit.service.NXAuditEventsService` component allows to
+define the adapter that will be injected in the EL context. Here is an example
+of a contribution to this extension point.
 
 ```xml
 <extension target="org.nuxeo.ecm.platform.audit.service.NXAuditEventsService" point="adapter">
@@ -380,7 +437,9 @@ The contribution to the `adapter` extension point of the `org.nuxeo.ecm.platform
 
 ### Listener
 
-A post commit asynchronous listener is defined and an Event Bundle, which is an ordered set of events raised during a user operation, is pushed into the Audit log. Here is an example of a contribution to the `listener` extension point.
+A post commit asynchronous listener is defined and an Event Bundle, which is an
+ordered set of events raised during a user operation, is pushed into the Audit
+log. Here is an example of a contribution to the `listener` extension point.
 
 ```xml
 <extension target="org.nuxeo.ecm.core.event.EventServiceComponent" point="listener">
@@ -391,11 +450,15 @@ A post commit asynchronous listener is defined and an Event Bundle, which is an 
 
 [More details on the explorer.](http://explorer.nuxeo.com/nuxeo/site/distribution/latest/viewContribution/org.nuxeo.ecm.platform.audit.service.NXAuditEventsService--listener)
 
-Note that since 9.3 by default this listener is overridden by the [Nuxeo Stream audit writer]({{page page='nuxeo-stream'}}).
+Note that since 9.3 by default this listener is overridden by the
+[Nuxeo Stream audit writer]({{page page='nuxeo-stream'}}).
 
 ### Queues
 
-It is also possible to configure queues used by the Audit Service. Each queue is using a separate queue and a single thread for logging. The extension point used to define the queues' parameters is `queue` for the `org.nuxeo.ecm.core.work.service` target.
+It is also possible to configure queues used by the Audit Service. Each queue is
+using a separate queue and a single thread for logging. The extension point used
+to define the queues' parameters is `queue` for the
+`org.nuxeo.ecm.core.work.service` target.
 
 ```xml
 <extension target="org.nuxeo.ecm.core.work.service" point="queues">
@@ -413,7 +476,10 @@ It is also possible to configure queues used by the Audit Service. Each queue is
 
 ### Hibernate - Legacy SQL Back-end Only
 
-In the legacy SQL back-end, the Audit Service  uses Hibernate as a JPA provider. The configuration is done in the `hibernate` extension point for the `org.nuxeo.ecm.core.persistence.PersistenceComponent` target. This extension point lets you override the default Hibernate configuration.
+In the legacy SQL back-end, the Audit Service  uses Hibernate as a JPA provider.
+The configuration is done in the `hibernate` extension point for the
+`org.nuxeo.ecm.core.persistence.PersistenceComponent` target. This extension
+point lets you override the default Hibernate configuration.
 
 ```xml
 <extension target="org.nuxeo.ecm.core.persistence.PersistenceComponent" point="hibernate">

--- a/src/nxdoc/nuxeo-server/data-store/data-modeling/audit.md
+++ b/src/nxdoc/nuxeo-server/data-store/data-modeling/audit.md
@@ -152,76 +152,18 @@ a map.
 Since LTS 2025, you have to explicitly choose a backend implementation from the
 following implementations listed below:
 
-| Backend                                  | Marketplace Package             |
-|------------------------------------------|---------------------------------|
-| In-Memory (not for production)           | Built-in Nuxeo Server (default) |
-| OpenSearch 1.x / Elasticsearch 7.x - 8.x | nuxeo-audit-opensearch1         |
-| OpenSearch 2.x                           | nuxeo-audit-opensearch2         |
-| Elasticsearch 9.x                        | nuxeo-audit-elasticsearch9      |
-| MongoDB                                  | nuxeo-audit-mongodb             |
-| SQL DataBase (Legacy)                    | nuxeo-audit-sql                 |
+| Backend                                  | Marketplace Package             | Reference                                                                          |
+|------------------------------------------|---------------------------------|------------------------------------------------------------------------------------|
+| In-Memory (not for production)           | Built-in Nuxeo Server (default) | —                                                                                  |
+| OpenSearch 1.x / Elasticsearch 7.x - 8.x | nuxeo-audit-opensearch1         | [OpenSearch 1.x Audit Backend]({{page page='audit-backend-opensearch1'}})          |
+| OpenSearch 2.x                           | nuxeo-audit-opensearch2         | [OpenSearch 2.x Audit Backend]({{page page='audit-backend-opensearch2'}})          |
+| Elasticsearch 9.x                        | nuxeo-audit-elasticsearch9      | [Elasticsearch 9.x Audit Backend]({{page page='audit-backend-elasticsearch9'}})    |
+| MongoDB                                  | nuxeo-audit-mongodb             | [MongoDB Audit Backend]({{page page='audit-backend-mongodb'}})                     |
+| SQL Database (Legacy)                    | nuxeo-audit-sql                 | [SQL Audit Backend (Legacy)]({{page page='audit-backend-sql'}})                      |
 
-More information below.
-
-#### OpenSearch 1.x / Elasticsearch 7.x - 8.x Back-end
-
-By installing the `nuxeo-audit-opensearch1` package, you have the previous
-default behavior of storing audit into an OpenSearch 1.x / Elasticsearch 7.x -
-8.x cluster.
-
-The audit entries are stored in an OpenSearch index named by the
-`nuxeo.audit.backend.default.opensearch1.index.name` property (previously
-`audit.elasticsearch.indexName`) in `nuxeo.conf`.
-
-{{#> callout type='warning' }}
-Make sure you read the
-[Backing Up and Restoring the Audit Elasticsearch Index]({{page page='backup-and-restore'}}#backingupandrestoringtheauditelasticsearchindex)
-section.
-{{/callout}}
-
-Fore more information about the global Elasticsearch setup, see
-[Elasticsearch Setup]({{page page='elasticsearch-setup'}}).
-
-#### OpenSearch 2.x Back-end
-
-To use OpenSearch 2.x back-end, you have to install the
-`nuxeo-audit-opensearch2` package.
-
-The entries are stored in the `nuxeo-audit` index by default. You can configure
-it by setting the `nuxeo.audit.backend.default.opensearch2.index.name` property
-in your `nuxeo.conf`.
-
-#### Elasticsearch 9.x Back-end
-
-To use Elasticsearch 9.x back-end, you have to install the
-`nuxeo-audit-elasticsearch9` package.
-
-The entries are stored in the `nuxeo-audit` index by default. You can configure
-it by setting the `nuxeo.audit.backend.default.elasticsearch9.index.name`
-property in your `nuxeo.conf`.
-
-#### MongoDB Back-end
-
-To use MongoDB back-end, you have to install the `nuxeo-audit-mongodb` package.
-
-The entries are stored in the `audit` collection by default. You can configure
-it by setting the `nuxeo.mongodb.audit.collection.name` property in your
+Each child page lists the configuration properties exposed by the package as
+`nuxeo.audit.backend.default.<implementation>.*` so you can override them in
 `nuxeo.conf`.
-
-#### Legacy SQL Back-end
-
-To use the legacy SQL back-end, you have to install the `nuxeo-audit-sql`
-package.
-
-The `LogEntry` and `ExtendedInfo` Java classes are mapped onto the datastore
-using JPA (Java Persistence API) annotations.
-
-There are three tables used by the Audit Service: `NXP_LOGS`, `NXP_LOGS_EXTINFO`
-and `NXP_LOGS_MAPEXTINFOS`. `NXP_LOGS` is the main table, it is used most of the
-time. The two others are used only when the `extendedInfo` extension point is
-defined.
-
-![]({{file name='diagram.png'}} ?w=600,border=true)
 
 ## Querying the Audit Data Store
 
@@ -244,41 +186,6 @@ List<LogEntry> logEntries = reader.getLogEntriesFor(doc.getId(), 'myRepository')
 AuditQueryBuilder builder = new AuditQueryBuilder();
 builder.predicates(Predicates.eq("docUUID", doc.getId()), Predicates.eq("repositoryId", 'myRepository'));
 List<LogEntry> logEntriesFiltered = reader.queryLogs(builder);
-```
-
-You can perform some simple queries using the Elasticsearch API, here is an
-example of getting all the logs of the category 'MyExport' ordered by the date
-of the event:
-
-```java
-List<LogEntry> entries = new ArrayList<>();
-ElasticSearchAdmin esa = Framework.getService(ElasticSearchAdmin.class);
-SearchRequestBuilder builder = esa.getClient()
-                                  .prepareSearch(esa.getIndexNameForType(ElasticSearchConstants.ENTRY_TYPE))
-                                  .setTypes(ElasticSearchConstants.ENTRY_TYPE)
-                                  .setSearchType(SearchType.DFS_QUERY_THEN_FETCH);
-builder.setQuery(QueryBuilders.termQuery("category", "MyExport"));
-builder.addSort("eventDate", SortOrder.DESC);
-SearchResponse searchResponse = builder.execute().actionGet();
-for (SearchHit hit : searchResponse.getHits()) {
-    try {
-        entries.add(AuditEntryJSONReader.read(hit.getSourceAsString()));
-    } catch (IOException e) {
-        log.error("Error while reading Audit Entry from ES", e);
-    }
-}
-```
-
-When using the legacy SQL back-end, you can use `AuditReader` to do simple
-queries using the JPA Query language:
-
-```java
-StringBuffer query = new StringBuffer("from LogEntry log where ");
-query.append(" log.category='");
-query.append("MyExport");
-query.append("'  ORDER BY log.eventDate DESC");
-AuditReader reader = Framework.getService(AuditReader.class);
-List<LogEntry> result = (List<LogEntry>)reader.nativeQuery(query.toString(), 1, 1);
 ```
 
 There are two PageProviders that can be used for querying the Audit data store:
@@ -473,23 +380,3 @@ to define the queues' parameters is `queue` for the
 ```
 
 [More details on the explorer.](http://explorer.nuxeo.com/nuxeo/site/distribution/latest/viewExtensionPoint/org.nuxeo.ecm.core.work.service--queues)
-
-### Hibernate - Legacy SQL Back-end Only
-
-In the legacy SQL back-end, the Audit Service  uses Hibernate as a JPA provider.
-The configuration is done in the `hibernate` extension point for the
-`org.nuxeo.ecm.core.persistence.PersistenceComponent` target. This extension
-point lets you override the default Hibernate configuration.
-
-```xml
-<extension target="org.nuxeo.ecm.core.persistence.PersistenceComponent" point="hibernate">
-  <hibernateConfiguration name="nxaudit-logs">
-    <datasource>nxaudit-logs</datasource>
-    <properties>
-      <property name="hibernate.hbm2ddl.auto">update</property>
-    </properties>
-  </hibernateConfiguration>
-</extension>
-```
-
-[More details on the explorer.](http://explorer.nuxeo.com/nuxeo/site/distribution/latest/viewExtensionPoint/org.nuxeo.ecm.core.persistence.PersistenceComponent--hibernate)

--- a/src/nxdoc/nuxeo-server/data-store/data-modeling/audit/audit-backend-elasticsearch9.md
+++ b/src/nxdoc/nuxeo-server/data-store/data-modeling/audit/audit-backend-elasticsearch9.md
@@ -1,0 +1,70 @@
+---
+title: Elasticsearch 9.x Audit Backend
+description: Elasticsearch 9.x Audit Backend for Nuxeo — installation, available configuration properties.
+review:
+    comment: ''
+    date: '2026-05-07'
+    status: ok
+labels:
+    - audit
+    - elasticsearch9
+toc: true
+tree_item_index: 750
+---
+
+{{! excerpt}}
+The Elasticsearch 9.x Audit Backend stores log entries in an Elasticsearch 9.x cluster.
+{{! /excerpt}}
+
+## Installation
+
+Install the `nuxeo-audit-elasticsearch9` Marketplace Package.
+
+It deploys the `elasticsearch9-audit` template, which sets
+`nuxeo.audit.backend.default.factory` to
+`org.nuxeo.audit.elasticsearch9.ElasticsearchAuditBackendFactory` and
+contributes a default `audit/default` Elasticsearch client and index named
+`nuxeo-audit`.
+
+## Configuration
+
+### Backend
+
+| Property                                                          | Default                                              | Description                                            |
+|-------------------------------------------------------------------|------------------------------------------------------|--------------------------------------------------------|
+| `nuxeo.audit.backend.default.factory`                             | `…elasticsearch9.ElasticsearchAuditBackendFactory`   | Factory class used by the default backend.             |
+| `nuxeo.audit.backend.default.elasticsearch9.enabled`              | `true`                                               | Enables/disables the default Elasticsearch 9.x backend.|
+| `nuxeo.audit.backend.default.elasticsearch9.index.name`           | `nuxeo-audit`                                        | Index name.                                            |
+| `nuxeo.audit.elasticsearch9.latestLogId.afterDate`                | `now-14d/d`                                          | Elastic date math used by `getLatestLogId`.            |
+
+### Client
+
+| Property                                                                             | Default     | Description                                            |
+|--------------------------------------------------------------------------------------|-------------|--------------------------------------------------------|
+| `nuxeo.audit.backend.default.elasticsearch9.client.server`                           |             | Comma-separated list of node URLs.                     |
+| `nuxeo.audit.backend.default.elasticsearch9.client.connectionTimeout`                | `30s`       | Connection timeout.                                    |
+| `nuxeo.audit.backend.default.elasticsearch9.client.socketTimeout`                    | `121000ms`  | Socket timeout.                                        |
+| `nuxeo.audit.backend.default.elasticsearch9.client.sslCertificateVerification`       | `true`      | Whether to verify the SSL certificate.                 |
+| `nuxeo.audit.backend.default.elasticsearch9.client.username`                         |             | Basic auth username.                                   |
+| `nuxeo.audit.backend.default.elasticsearch9.client.password`                         |             | Basic auth password.                                   |
+| `nuxeo.audit.backend.default.elasticsearch9.client.trustStore.path`                  |             | Path to a truststore.                                  |
+| `nuxeo.audit.backend.default.elasticsearch9.client.trustStore.password`              |             | Truststore password.                                   |
+| `nuxeo.audit.backend.default.elasticsearch9.client.trustStore.type`                  |             | Truststore type (e.g. `JKS`).                          |
+| `nuxeo.audit.backend.default.elasticsearch9.client.keyStore.path`                    |             | Path to a keystore.                                    |
+| `nuxeo.audit.backend.default.elasticsearch9.client.keyStore.password`                |             | Keystore password.                                     |
+| `nuxeo.audit.backend.default.elasticsearch9.client.keyStore.type`                    |             | Keystore type.                                         |
+
+### Index settings
+
+| Property                                                                             | Default   | Description                                |
+|--------------------------------------------------------------------------------------|-----------|--------------------------------------------|
+| `nuxeo.audit.backend.default.elasticsearch9.settings.indexTranslogDurability`        | `request` | Index translog durability.                 |
+| `nuxeo.audit.backend.default.elasticsearch9.settings.numberOfShards`                 | `5`       | Number of primary shards.                  |
+| `nuxeo.audit.backend.default.elasticsearch9.settings.numberOfReplicas`               | `1`       | Number of replicas.                        |
+| `nuxeo.audit.backend.default.elasticsearch9.settings.ignoreMalformed`                | `true`    | Ignore malformed values during indexing.   |
+
+## Learn More
+
+- [Audit]({{page page='audit'}})
+- [Audit Router]({{page page='audit-router'}})
+- [Elasticsearch 9.x Search Setup]({{page page='search-setup-elasticsearch9'}})

--- a/src/nxdoc/nuxeo-server/data-store/data-modeling/audit/audit-backend-elasticsearch9.md
+++ b/src/nxdoc/nuxeo-server/data-store/data-modeling/audit/audit-backend-elasticsearch9.md
@@ -49,7 +49,7 @@ contributes a default `audit/default` Elasticsearch client and index named
 | `nuxeo.audit.backend.default.elasticsearch9.client.password`                         |             | Basic auth password.                                   |
 | `nuxeo.audit.backend.default.elasticsearch9.client.trustStore.path`                  |             | Path to a truststore.                                  |
 | `nuxeo.audit.backend.default.elasticsearch9.client.trustStore.password`              |             | Truststore password.                                   |
-| `nuxeo.audit.backend.default.elasticsearch9.client.trustStore.type`                  |             | Truststore type (e.g. `JKS`).                          |
+| `nuxeo.audit.backend.default.elasticsearch9.client.trustStore.type`                  |             | Truststore type (for example, `JKS`).                          |
 | `nuxeo.audit.backend.default.elasticsearch9.client.keyStore.path`                    |             | Path to a keystore.                                    |
 | `nuxeo.audit.backend.default.elasticsearch9.client.keyStore.password`                |             | Keystore password.                                     |
 | `nuxeo.audit.backend.default.elasticsearch9.client.keyStore.type`                    |             | Keystore type.                                         |

--- a/src/nxdoc/nuxeo-server/data-store/data-modeling/audit/audit-backend-mongodb.md
+++ b/src/nxdoc/nuxeo-server/data-store/data-modeling/audit/audit-backend-mongodb.md
@@ -1,0 +1,66 @@
+---
+title: MongoDB Audit Backend
+description: MongoDB Audit Backend for Nuxeo — installation, available configuration properties.
+review:
+    comment: ''
+    date: '2026-05-07'
+    status: ok
+labels:
+    - audit
+    - mongodb
+    - mongodb-component
+toc: true
+tree_item_index: 720
+---
+
+{{! excerpt}}
+The MongoDB Audit Backend stores log entries in a MongoDB collection.
+{{! /excerpt}}
+
+## Installation
+
+Install the `nuxeo-audit-mongodb` Marketplace Package.
+
+It deploys the `mongodb-audit` template, which sets `nuxeo.audit.backend.default.factory`
+to `org.nuxeo.audit.mongodb.MongoDBAuditBackendFactory` and contributes a
+default `audit/default` MongoDB connection.
+
+By default the entries are stored in the `audit` collection, fed by the `audit`
+database (the connection inherits the `nuxeo.mongodb.*` properties).
+
+## Configuration
+
+### Backend
+
+| Property                                                | Default                                  | Description                                                  |
+|---------------------------------------------------------|------------------------------------------|--------------------------------------------------------------|
+| `nuxeo.audit.backend.default.factory`                   | `…MongoDBAuditBackendFactory`            | Factory class used by the default backend.                   |
+| `nuxeo.audit.backend.default.mongodb.enabled`           | `true`                                   | Enables/disables the default MongoDB backend.                |
+| `nuxeo.audit.backend.default.mongodb.collection.name`   | `${nuxeo.mongodb.audit.collection.name:=audit}` | Name of the MongoDB collection storing log entries.   |
+
+### Connection
+
+The MongoDB Audit Backend uses a dedicated `audit/default` MongoDB connection.
+By default each property falls back to the corresponding `nuxeo.mongodb.*`
+property already configured for the repository.
+
+| Property                                                       | Falls back to                       |
+|----------------------------------------------------------------|-------------------------------------|
+| `nuxeo.audit.backend.default.mongodb.server`                   | `nuxeo.mongodb.server`              |
+| `nuxeo.audit.backend.default.mongodb.dbname`                   | `nuxeo.mongodb.dbname`              |
+| `nuxeo.audit.backend.default.mongodb.ssl`                      | `nuxeo.mongodb.ssl`                 |
+| `nuxeo.audit.backend.default.mongodb.truststore.path`          | `nuxeo.mongodb.truststore.path`     |
+| `nuxeo.audit.backend.default.mongodb.truststore.password`      | `nuxeo.mongodb.truststore.password` |
+| `nuxeo.audit.backend.default.mongodb.truststore.type`          | `nuxeo.mongodb.truststore.type`     |
+| `nuxeo.audit.backend.default.mongodb.keystore.path`            | `nuxeo.mongodb.keystore.path`       |
+| `nuxeo.audit.backend.default.mongodb.keystore.password`        | `nuxeo.mongodb.keystore.password`   |
+| `nuxeo.audit.backend.default.mongodb.keystore.type`            | `nuxeo.mongodb.keystore.type`       |
+
+Set any of those properties in `nuxeo.conf` to point the audit to a separate
+MongoDB cluster than the repository.
+
+## Learn More
+
+- [Audit]({{page page='audit'}})
+- [Audit Router]({{page page='audit-router'}})
+- [MongoDB Setup]({{page page='mongodb'}})

--- a/src/nxdoc/nuxeo-server/data-store/data-modeling/audit/audit-backend-opensearch1.md
+++ b/src/nxdoc/nuxeo-server/data-store/data-modeling/audit/audit-backend-opensearch1.md
@@ -68,7 +68,7 @@ legacy `elasticsearch.restClient.*` property.
 | `nuxeo.audit.backend.default.opensearch1.client.password`                         |             | Basic auth password.                                   |
 | `nuxeo.audit.backend.default.opensearch1.client.trustStore.path`                  |             | Path to a truststore.                                  |
 | `nuxeo.audit.backend.default.opensearch1.client.trustStore.password`              |             | Truststore password.                                   |
-| `nuxeo.audit.backend.default.opensearch1.client.trustStore.type`                  |             | Truststore type (e.g. `JKS`).                          |
+| `nuxeo.audit.backend.default.opensearch1.client.trustStore.type`                  |             | Truststore type (for example, `JKS`).                          |
 | `nuxeo.audit.backend.default.opensearch1.client.keyStore.path`                    |             | Path to a keystore.                                    |
 | `nuxeo.audit.backend.default.opensearch1.client.keyStore.password`                |             | Keystore password.                                     |
 | `nuxeo.audit.backend.default.opensearch1.client.keyStore.type`                    |             | Keystore type.                                         |

--- a/src/nxdoc/nuxeo-server/data-store/data-modeling/audit/audit-backend-opensearch1.md
+++ b/src/nxdoc/nuxeo-server/data-store/data-modeling/audit/audit-backend-opensearch1.md
@@ -1,0 +1,89 @@
+---
+title: OpenSearch 1.x / Elasticsearch 7-8 Audit Backend
+description: OpenSearch 1.x / Elasticsearch 7-8 Audit Backend for Nuxeo — installation, available configuration properties.
+review:
+    comment: ''
+    date: '2026-05-07'
+    status: ok
+labels:
+    - audit
+    - opensearch1
+    - elasticsearch
+toc: true
+tree_item_index: 730
+---
+
+{{! excerpt}}
+The OpenSearch 1.x Audit Backend stores log entries in an OpenSearch 1.x or
+Elasticsearch 7.x – 8.x cluster. This package replaces the legacy Elasticsearch-based audit backend.
+{{! /excerpt}}
+
+## Installation
+
+Install the `nuxeo-audit-opensearch1` Marketplace Package.
+
+It deploys the `opensearch1-audit` template, which sets
+`nuxeo.audit.backend.default.factory` to
+`org.nuxeo.audit.opensearch1.OpenSearchAuditBackendFactory` and contributes a
+default `audit/default` OpenSearch client and index.
+
+{{#> callout type='warning' }}
+Make sure you read the [Backing Up and Restoring the Audit Elasticsearch Index]({{page page='backup-and-restore'}}#backingupandrestoringtheauditelasticsearchindex) section.
+{{/callout}}
+
+For more information about the global Elasticsearch / OpenSearch setup, see
+[OpenSearch 1.x Search Setup]({{page page='search-setup-opensearch1'}}).
+
+## Configuration
+
+The audit backend reuses the OpenSearch 1.x infrastructure deployed by
+`nuxeo-opensearch1`. When the `nuxeo-opensearch1-embed` Marketplace Package
+is installed alongside, the audit backend reuses the embedded OpenSearch
+node deployed by that package (controlled internally by the
+`nuxeo.opensearch1.embed.enabled` flag). The embed package is intended for
+development only and is not supported in production.
+
+### Backend
+
+| Property                                                          | Default                                                          | Description                                                                                                                            |
+|-------------------------------------------------------------------|------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
+| `nuxeo.audit.backend.default.factory`                             | `…opensearch1.OpenSearchAuditBackendFactory`                     | Factory class used by the default backend.                                                                                             |
+| `nuxeo.audit.backend.default.opensearch1.enabled`                 | `true`                                                           | Enables/disables the default OpenSearch 1.x backend.                                                                                   |
+| `nuxeo.audit.backend.default.opensearch1.index.name`              | `${audit.elasticsearch.indexName:=${elasticsearch.indexName:=nuxeo}-audit}` | Index name. Replaces the legacy `audit.elasticsearch.indexName` property.                                                    |
+| `nuxeo.audit.opensearch1.latestLogId.afterDate`                   | `now-14d/d`                                                      | Elastic date math used by `getLatestLogId` to bound the lookup window. Improves performance on large indices.                          |
+
+### Client
+
+The audit ingestion uses a dedicated `audit/default` OpenSearch client. Each
+property falls back to its `nuxeo.opensearch1.*` equivalent and then to the
+legacy `elasticsearch.restClient.*` property.
+
+| Property                                                                          | Default     | Description                                            |
+|-----------------------------------------------------------------------------------|-------------|--------------------------------------------------------|
+| `nuxeo.audit.backend.default.opensearch1.client.server`                           |             | Comma-separated list of node URLs.                     |
+| `nuxeo.audit.backend.default.opensearch1.client.connectionTimeout`                | `30s`       | Connection timeout.                                    |
+| `nuxeo.audit.backend.default.opensearch1.client.socketTimeout`                    | `121000ms`  | Socket timeout.                                        |
+| `nuxeo.audit.backend.default.opensearch1.client.sslCertificateVerification`       | `true`      | Whether to verify the SSL certificate.                 |
+| `nuxeo.audit.backend.default.opensearch1.client.username`                         |             | Basic auth username.                                   |
+| `nuxeo.audit.backend.default.opensearch1.client.password`                         |             | Basic auth password.                                   |
+| `nuxeo.audit.backend.default.opensearch1.client.trustStore.path`                  |             | Path to a truststore.                                  |
+| `nuxeo.audit.backend.default.opensearch1.client.trustStore.password`              |             | Truststore password.                                   |
+| `nuxeo.audit.backend.default.opensearch1.client.trustStore.type`                  |             | Truststore type (e.g. `JKS`).                          |
+| `nuxeo.audit.backend.default.opensearch1.client.keyStore.path`                    |             | Path to a keystore.                                    |
+| `nuxeo.audit.backend.default.opensearch1.client.keyStore.password`                |             | Keystore password.                                     |
+| `nuxeo.audit.backend.default.opensearch1.client.keyStore.type`                    |             | Keystore type.                                         |
+
+### Index settings
+
+| Property                                                                          | Default   | Description                                |
+|-----------------------------------------------------------------------------------|-----------|--------------------------------------------|
+| `nuxeo.audit.backend.default.opensearch1.settings.indexTranslogDurability`        | `request` | Index translog durability.                 |
+| `nuxeo.audit.backend.default.opensearch1.settings.numberOfShards`                 | `5`       | Number of primary shards.                  |
+| `nuxeo.audit.backend.default.opensearch1.settings.numberOfReplicas`               | `1`       | Number of replicas.                        |
+| `nuxeo.audit.backend.default.opensearch1.settings.ignoreMalformed`                | `true`    | Ignore malformed values during indexing.   |
+
+## Learn More
+
+- [Audit]({{page page='audit'}})
+- [Audit Router]({{page page='audit-router'}})
+- [OpenSearch 1.x Search Setup]({{page page='search-setup-opensearch1'}})

--- a/src/nxdoc/nuxeo-server/data-store/data-modeling/audit/audit-backend-opensearch2.md
+++ b/src/nxdoc/nuxeo-server/data-store/data-modeling/audit/audit-backend-opensearch2.md
@@ -58,7 +58,7 @@ property falls back to its `nuxeo.opensearch2.*` equivalent.
 | `nuxeo.audit.backend.default.opensearch2.client.password`                         |             | Basic auth password.                                   |
 | `nuxeo.audit.backend.default.opensearch2.client.trustStore.path`                  |             | Path to a truststore.                                  |
 | `nuxeo.audit.backend.default.opensearch2.client.trustStore.password`              |             | Truststore password.                                   |
-| `nuxeo.audit.backend.default.opensearch2.client.trustStore.type`                  |             | Truststore type (e.g. `JKS`).                          |
+| `nuxeo.audit.backend.default.opensearch2.client.trustStore.type`                  |             | Truststore type (for example, `JKS`).                          |
 | `nuxeo.audit.backend.default.opensearch2.client.keyStore.path`                    |             | Path to a keystore.                                    |
 | `nuxeo.audit.backend.default.opensearch2.client.keyStore.password`                |             | Keystore password.                                     |
 | `nuxeo.audit.backend.default.opensearch2.client.keyStore.type`                    |             | Keystore type.                                         |

--- a/src/nxdoc/nuxeo-server/data-store/data-modeling/audit/audit-backend-opensearch2.md
+++ b/src/nxdoc/nuxeo-server/data-store/data-modeling/audit/audit-backend-opensearch2.md
@@ -1,0 +1,79 @@
+---
+title: OpenSearch 2.x Audit Backend
+description: OpenSearch 2.x Audit Backend for Nuxeo — installation, available configuration properties.
+review:
+    comment: ''
+    date: '2026-05-07'
+    status: ok
+labels:
+    - audit
+    - opensearch2
+toc: true
+tree_item_index: 740
+---
+
+{{! excerpt}}
+The OpenSearch 2.x Audit Backend stores log entries in an OpenSearch 2.x cluster.
+{{! /excerpt}}
+
+## Installation
+
+Install the `nuxeo-audit-opensearch2` Marketplace Package.
+
+It deploys the `opensearch2-audit` template, which sets
+`nuxeo.audit.backend.default.factory` to
+`org.nuxeo.audit.opensearch2.OpenSearchAuditBackendFactory` and contributes a
+default `audit/default` OpenSearch client and index named `nuxeo-audit`.
+
+## Configuration
+
+The audit backend reuses the OpenSearch 2.x infrastructure deployed by
+`nuxeo-opensearch2`. When the `nuxeo-opensearch2-embed` Marketplace Package
+is installed alongside, the audit backend reuses the embedded OpenSearch
+node deployed by that package (controlled internally by the
+`nuxeo.opensearch2.embed.enabled` flag). The embed package is intended for
+development only and is not supported in production.
+
+### Backend
+
+| Property                                                       | Default                                          | Description                                          |
+|----------------------------------------------------------------|--------------------------------------------------|------------------------------------------------------|
+| `nuxeo.audit.backend.default.factory`                          | `…opensearch2.OpenSearchAuditBackendFactory`     | Factory class used by the default backend.           |
+| `nuxeo.audit.backend.default.opensearch2.enabled`              | `true`                                           | Enables/disables the default OpenSearch 2.x backend. |
+| `nuxeo.audit.backend.default.opensearch2.index.name`           | `nuxeo-audit`                                    | Index name.                                          |
+| `nuxeo.audit.opensearch2.latestLogId.afterDate`                | `now-14d/d`                                      | Elastic date math used by `getLatestLogId`.          |
+
+### Client
+
+The audit ingestion uses a dedicated `audit/default` OpenSearch client. Each
+property falls back to its `nuxeo.opensearch2.*` equivalent.
+
+| Property                                                                          | Default     | Description                                            |
+|-----------------------------------------------------------------------------------|-------------|--------------------------------------------------------|
+| `nuxeo.audit.backend.default.opensearch2.client.server`                           |             | Comma-separated list of node URLs.                     |
+| `nuxeo.audit.backend.default.opensearch2.client.connectionTimeout`                | `30s`       | Connection timeout.                                    |
+| `nuxeo.audit.backend.default.opensearch2.client.socketTimeout`                    | `121000ms`  | Socket timeout.                                        |
+| `nuxeo.audit.backend.default.opensearch2.client.sslCertificateVerification`       | `true`      | Whether to verify the SSL certificate.                 |
+| `nuxeo.audit.backend.default.opensearch2.client.username`                         |             | Basic auth username.                                   |
+| `nuxeo.audit.backend.default.opensearch2.client.password`                         |             | Basic auth password.                                   |
+| `nuxeo.audit.backend.default.opensearch2.client.trustStore.path`                  |             | Path to a truststore.                                  |
+| `nuxeo.audit.backend.default.opensearch2.client.trustStore.password`              |             | Truststore password.                                   |
+| `nuxeo.audit.backend.default.opensearch2.client.trustStore.type`                  |             | Truststore type (e.g. `JKS`).                          |
+| `nuxeo.audit.backend.default.opensearch2.client.keyStore.path`                    |             | Path to a keystore.                                    |
+| `nuxeo.audit.backend.default.opensearch2.client.keyStore.password`                |             | Keystore password.                                     |
+| `nuxeo.audit.backend.default.opensearch2.client.keyStore.type`                    |             | Keystore type.                                         |
+
+### Index settings
+
+| Property                                                                          | Default   | Description                                |
+|-----------------------------------------------------------------------------------|-----------|--------------------------------------------|
+| `nuxeo.audit.backend.default.opensearch2.settings.indexTranslogDurability`        | `request` | Index translog durability.                 |
+| `nuxeo.audit.backend.default.opensearch2.settings.numberOfShards`                 | `5`       | Number of primary shards.                  |
+| `nuxeo.audit.backend.default.opensearch2.settings.numberOfReplicas`               | `1`       | Number of replicas.                        |
+| `nuxeo.audit.backend.default.opensearch2.settings.ignoreMalformed`                | `true`    | Ignore malformed values during indexing.   |
+
+## Learn More
+
+- [Audit]({{page page='audit'}})
+- [Audit Router]({{page page='audit-router'}})
+- [OpenSearch 2.x Search Setup]({{page page='search-setup-opensearch2'}})

--- a/src/nxdoc/nuxeo-server/data-store/data-modeling/audit/audit-backend-sql.md
+++ b/src/nxdoc/nuxeo-server/data-store/data-modeling/audit/audit-backend-sql.md
@@ -1,0 +1,79 @@
+---
+title: SQL Audit Backend (Legacy)
+description: Legacy SQL Audit Backend for Nuxeo — installation, JPA storage and Hibernate configuration.
+review:
+    comment: ''
+    date: '2026-05-07'
+    status: ok
+labels:
+    - audit
+    - sql
+toc: true
+tree_item_index: 760
+---
+
+{{! excerpt}}
+The legacy SQL Audit Backend stores log entries in a relational database using
+JPA / Hibernate. It is intended for small deployments only.
+{{! /excerpt}}
+
+## Installation
+
+Install the `nuxeo-audit-sql` Marketplace Package.
+
+It deploys the `sql-audit` template, which sets
+`nuxeo.audit.backend.default.factory` to
+`org.nuxeo.audit.sql.SQLAuditBackendFactory`.
+
+The `LogEntry` and `ExtendedInfo` Java classes are mapped onto the datastore
+using JPA (Java Persistence API) annotations. Three tables are used by the
+backend:
+
+- `NXP_LOGS` — the main table, used most of the time.
+- `NXP_LOGS_EXTINFO`
+- `NXP_LOGS_MAPEXTINFOS`
+
+The two `*EXTINFO*` tables are populated only when the `extendedInfo` extension
+point is contributed.
+
+![]({{file name='diagram.png' page='audit'}} ?w=600,border=true)
+
+## Hibernate Configuration
+
+The SQL Audit Backend uses Hibernate as a JPA provider. The configuration is
+done in the `hibernate` extension point of the
+`org.nuxeo.ecm.core.persistence.PersistenceComponent` target. This extension
+point lets you override the default Hibernate configuration.
+
+```xml
+<extension target="org.nuxeo.ecm.core.persistence.PersistenceComponent" point="hibernate">
+  <hibernateConfiguration name="nxaudit-logs">
+    <datasource>nxaudit-logs</datasource>
+    <properties>
+      <property name="hibernate.hbm2ddl.auto">update</property>
+    </properties>
+  </hibernateConfiguration>
+</extension>
+```
+
+[More details on the explorer.](http://explorer.nuxeo.com/nuxeo/site/distribution/latest/viewExtensionPoint/org.nuxeo.ecm.core.persistence.PersistenceComponent--hibernate)
+
+## Search Behavior
+
+The default audit route shipped with this package disables the `search` event
+to avoid storing every search query in the SQL database:
+
+```xml
+<extension target="org.nuxeo.audit.service.AuditComponent" point="routes">
+  <route name="default">
+    <event name="search" enabled="false" />
+  </route>
+</extension>
+```
+
+Re-enable it explicitly if you need the `search` event audited on the SQL backend.
+
+## Learn More
+
+- [Audit]({{page page='audit'}})
+- [Audit Router]({{page page='audit-router'}})

--- a/src/nxdoc/nuxeo-server/data-store/data-modeling/audit/audit-router.md
+++ b/src/nxdoc/nuxeo-server/data-store/data-modeling/audit/audit-router.md
@@ -1,0 +1,204 @@
+---
+title: Audit Router
+description: Route audit log entries to one or more Audit Backends based on event names and predicates.
+review:
+    comment: ''
+    date: '2026-05-07'
+    status: ok
+labels:
+    - audit
+    - audit-router
+toc: true
+tree_item_index: 770
+---
+
+{{#> callout type='warning' heading='Available since 2025.16'}}
+The Audit Router and the `routes` extension point are introduced in Nuxeo
+2025.16. Until then, only the legacy `event` extension point is available.
+The legacy `event` extension point still works and remains backward-compatible
+on later releases.
+{{/callout}}
+
+{{! excerpt}}
+The `AuditRouter` is the engine that decides, for each Nuxeo event, which Audit
+Backend(s) the resulting `LogEntry` is written to. It is configured through the
+`routes` extension point of the Audit Service.
+{{! /excerpt}}
+
+## How Routing Works
+
+The audit ingestion pipeline goes through three stages:
+
+1. The `StreamAuditEventListener` intercepts each audited event, asks the
+   `AuditRouter` to compute the resulting `LogEntry` from the event context,
+   and the listener appends it to the `audit/audit` Nuxeo Stream.
+2. The `audit/writer` computation (`StreamAuditWriter`) consumes the
+   `audit/audit` stream entries.
+3. For every entry, the computation calls the `AuditRouter` back to get the
+   list of target backends. The router walks the contributed routes and, for
+   every route that matches the entry, returns the configured backend. The
+   entry is then written to each matching backend.
+
+![]({{file name='architecture-diagram.png' page='audit'}} ?w=600,border=true)
+
+The combination semantics are:
+
+- **routes are ORed**: a single log entry can be written to several backends if
+  several routes match.
+- **events** of one route are ORed.
+- **predicates** of one route are ORed.
+- **events AND predicates** are combined inside a single route: a route
+  declaring both accepts an entry only when one of its events matches **and**
+  one of its predicates is satisfied.
+
+A route may declare only events, only predicates, or both:
+
+- **Events only** — the events declared in the route are registered as auditable events,
+  so the post-commit listener forwards them to the `audit/audit` stream.
+- **Predicates only** — the route does not register events; it only filters
+  log entries that already flow through the router (for example, to copy
+  entries flowing to the default backend to a secondary one based on their
+  category).
+
+## {{> anchor 'routes-extension-point'}}`routes` Extension Point
+
+A route is a `<route>` element with a `name`, a `<backend>` and any
+combination of `<event>` and `<predicate>` children:
+
+```xml
+<extension target="org.nuxeo.audit.service.AuditComponent" point="routes">
+  <route name="default">
+    <backend name="default" />
+    <event name="documentCreated" />
+    <event name="documentModified" enabled="true" />
+  </route>
+</extension>
+```
+
+By default the Nuxeo Platform contributes a `default` route holding all auditable events. Custom contributions to the `routes` extension point can override or extend this configuration.
+
+### `<backend>`
+
+`<backend name="..."/>` references a backend registered through the
+`backendFactory` extension point. The platform always contributes a `default`
+backend whose factory comes from `nuxeo.audit.backend.default.factory`.
+
+### `<event>`
+
+`<event name="..." enabled="true|false"/>` registers an auditable event.
+
+- The event must be one of the events fired by the platform (or by your code).
+- Setting `enabled="false"` is the supported way to suppress an event from a
+  route without redefining it; this is how the SQL backend disables `search`
+  by default.
+
+### `<predicate>`
+
+`<predicate class="..."/>` filters which log entries the route accepts. A
+predicate is a `java.util.function.Predicate<LogEntry>` that takes a
+`Map<String, String>` of `<property>` entries as constructor argument:
+
+```xml
+<route name="documentCategory">
+  <backend name="default" />
+  <predicate class="org.nuxeo.audit.service.route.CategoryLogEntryPredicate">
+    <property name="category">eventDocumentCategory</property>
+  </predicate>
+</route>
+```
+
+The platform ships `CategoryLogEntryPredicate`, which keeps log entries whose
+`category` matches the configured value. You can contribute your own
+`Predicate<LogEntry>` implementation by providing a public constructor that
+accepts a `Map<String, String>`.
+
+### Route Inheritance with `copy`
+
+A route can copy another existing route by referring to it via the `copy`
+attribute. The copying route inherits the backend and the events/predicates
+of the source route, and merges them with what it declares locally:
+
+- Locally declared `<event>` and `<predicate>` elements are merged with the
+  inherited ones (entries are identified by `name`). A local
+  `<event name="..." enabled="false"/>` disables a specific inherited event.
+- The `<backend>` is replaced when redeclared.
+
+```xml
+<route name="default-mirrored" copy="default">
+  <backend name="secondary" />
+</route>
+```
+
+## Worked Example — Routing a Business Event to a Secondary Backend
+
+The following example contributes a secondary OpenSearch 1.x backend that
+receives only the custom `hylandBusinessEvent` event. The default backend is
+left untouched: it keeps receiving the events declared by the implicit
+`default` route, and it does **not** receive `hylandBusinessEvent`.
+
+### 1. Register the secondary backend
+
+```xml
+<extension target="org.nuxeo.audit.service.AuditComponent" point="backendFactory">
+  <backend name="secondary" factory="org.nuxeo.audit.opensearch1.OpenSearchAuditBackendFactory" />
+</extension>
+```
+
+### 2. Configure the backend implementation
+
+```xml
+<extension target="org.nuxeo.audit.opensearch1.OpenSearchAuditBackendFactory" point="backend">
+  <backend name="secondary"
+           clientId="audit/secondary"
+           indexName="${hyland.custom.audit.backend.secondary.opensearch1.index.name:=hyland-business-audit}" />
+</extension>
+```
+
+### 3. Configure the OpenSearch client used by the secondary backend
+
+```xml
+<extension target="org.nuxeo.runtime.opensearch1.OpenSearchComponent" point="client">
+  <client id="audit/secondary">
+    <server>${hyland.custom.audit.backend.secondary.opensearch1.client.server:=http://localhost:9200}</server>
+    <connectionTimeout>${hyland.custom.audit.backend.secondary.opensearch1.client.connectionTimeout:=30s}</connectionTimeout>
+    <socketTimeout>${hyland.custom.audit.backend.secondary.opensearch1.client.socketTimeout:=121000ms}</socketTimeout>
+    <username>${hyland.custom.audit.backend.secondary.opensearch1.client.username:=}</username>
+    <password>${hyland.custom.audit.backend.secondary.opensearch1.client.password:=}</password>
+  </client>
+</extension>
+```
+
+### 4. Contribute the route
+
+```xml
+<extension target="org.nuxeo.audit.service.AuditComponent" point="routes">
+  <route name="secondary_route">
+    <backend name="secondary" />
+    <event name="hylandBusinessEvent" />
+  </route>
+</extension>
+```
+
+From now on, every `hylandBusinessEvent` raised by the application is ingested
+by the secondary OpenSearch backend, while regular events keep flowing to the
+default backend.
+
+{{#> callout type='warning' }}
+When installing two Audit Backend Marketplace Packages side-by-side, only one
+of them must be the default. Force the default factory in `nuxeo.conf` and
+disable the other one, for instance:
+
+```
+# default backend is SQL
+nuxeo.audit.backend.default.factory=org.nuxeo.audit.sql.SQLAuditBackendFactory
+# secondary OpenSearch package must not register itself as default
+nuxeo.audit.backend.default.opensearch1.enabled=false
+```
+{{/callout}}
+
+## Learn More
+
+- [Audit]({{page page='audit'}})
+- [Copy an Audit Backend]({{page page='copy-audit-backend'}})
+- [Audit Endpoint]({{page space='rest-api' version='1' page='audit-endpoint'}})
+- [How to Upgrade Nuxeo Audit Service]({{page page='how-to-upgrade-audit-service'}})

--- a/src/nxdoc/nuxeo-server/data-store/data-modeling/audit/copy-audit-backend.md
+++ b/src/nxdoc/nuxeo-server/data-store/data-modeling/audit/copy-audit-backend.md
@@ -1,0 +1,103 @@
+---
+title: Copy an Audit Backend
+description: Copy log entries from one Audit Backend to another using the audit scroll, the copyAudit bulk action and the Management REST API.
+review:
+    comment: ''
+    date: '2026-05-07'
+    status: ok
+labels:
+    - audit
+    - blue-green-migration
+toc: true
+tree_item_index: 780
+---
+
+{{#> callout type='warning' heading='Available since 2025.19'}}
+The audit scroller, the `copyAudit` bulk action and the related Management
+REST API endpoints are introduced in Nuxeo 2025.19.
+{{/callout}}
+
+{{! excerpt}}
+Copying log entries between two Audit Backends is the cornerstone of a
+**Blue/Green Audit migration** — for instance when upgrading from OpenSearch 1.x
+to OpenSearch 2.x, or when moving the audit out of SQL backend. Nuxeo provides a
+generic scroller, a `copyAudit` Bulk Action and Management REST endpoints to
+trigger and verify the copy.
+{{! /excerpt}}
+
+## Audit Scroll
+
+The `audit` scroll is a [Bulk Action Framework]({{page page='bulk-action-framework'}})
+scroller backed by the Audit `QueryBuilder` API. It scrolls log entry
+identifiers from one [Audit Backend]({{page page='audit'}}#audit-back-ends)
+based on a valid NXQL query whose `FROM` clause states the source backend.
+
+Constraints can be expressed on the `LogEntry` fields (`eventId`, `logDate`,
+`category`, …) like the Audit Page Provider already proposes; an `ORDER BY`
+clause is also supported. When no order is provided, the scroller orders by
+`id ASC` to keep the scroll deterministic.
+
+Example NXQL — scroll the `default` backend, oldest first:
+
+```sql
+SELECT * FROM default ORDER BY logDate ASC
+```
+
+The scroll only supports one backend per request — the audit `FROM` clause
+expects exactly one backend name.
+
+## `copyAudit` Bulk Action
+
+The `copyAudit` bulk action consumes the `audit` scroll and writes every
+scrolled `LogEntry` to a target backend. It is exclusive between two
+backends — a second copy from the same source to the same target is rejected
+as long as a previous one is still running.
+
+Default action configuration:
+
+| Property                                           | Default |
+|----------------------------------------------------|---------|
+| `nuxeo.bulk.action.copyAudit.defaultConcurrency`   | `2`     |
+| `nuxeo.bulk.action.copyAudit.defaultPartitions`    | `4`     |
+
+The action also tolerates failures: it retries up to 3 times with an
+exponential back-off (`500ms` → `10s`) before giving up.
+
+## Management REST API
+
+Three Management endpoints expose the copy / verification flow:
+
+| Endpoint                                | Purpose                                                     |
+|-----------------------------------------|-------------------------------------------------------------|
+| `POST /management/audit/copy`           | Trigger a `copyAudit` bulk action between two backends.     |
+| `GET  /management/audit/checkSearch`    | Run the same NXQL on several backends and compare results.  |
+| `GET  /management/audit/introspection`  | Get a PlantUML view of the live audit routing.              |
+
+## Typical Blue/Green Migration
+
+1. Deploy a secondary Audit Backend (referred to as the green backend, the live one being the default)
+   the `default` backend) — see the [Audit Router]({{page page='audit-router'}})
+   page.
+2. Contribute a [route]({{page page='audit-router'}}#routes-extension-point) to start mirroring live ingestion to the `green`
+   backend.
+3. Trigger `POST /management/audit/copy?from=default&to=green` to copy the
+   historical entries.
+4. Monitor the bulk command status using the [Bulk Endpoint]({{page space='rest-api' version='1' page='bulk-endpoint'}}).
+5. Validate using `GET /management/audit/checkSearch?backend=default&backend=green`.
+6. Promote the `green` backend as the new default — this is a repackaging
+   step that registers the `green` backend as the `default` backend and the
+   previous default configuration can be removed.
+7. (Optional) Delete the contents of the previous backend once you no longer
+   need to keep its historical data.
+
+{{#> callout type='info' heading='Coming next — Purge Audit Migration'}}
+The same building blocks (audit scroll + `copyAudit` style bulk action) will be
+reused to provide an uninterrupted **Audit Purge** capability.
+{{/callout}}
+
+## Learn More
+
+- [Audit]({{page page='audit'}})
+- [Audit Router]({{page page='audit-router'}})
+- [Audit Endpoint]({{page space='rest-api' version='1' page='audit-endpoint'}})
+- [Bulk Action Framework]({{page page='bulk-action-framework'}})


### PR DESCRIPTION
Refresh of the [Audit page](https://doc.nuxeo.com/nxdoc/audit/) for the LTS 2025 audit rework ([NXP-32866](https://hyland.atlassian.net/browse/NXP-32866)) and documentation of the two new epics covered by [NXDOC-2956](https://hyland.atlassian.net/browse/NXDOC-2956):

- [NXENG-17](https://hyland.atlassian.net/browse/NXENG-17) — Audit Router (since 2025.16)
- [NXENG-240](https://hyland.atlassian.net/browse/NXENG-240) — Blue/Green Audit migration (since 2025.19)

## Changes

The work is split in four commits to ease the review:

1. **Split Audit backend implementations into child pages** — moves the per-backend installation/configuration details out of the main page into one page per Marketplace Package (MongoDB, OpenSearch 1.x, OpenSearch 2.x, Elasticsearch 9.x, legacy SQL) and lists every `nuxeo.audit.backend.default.<impl>.*` property exposed by the package, the embedded OpenSearch / Elasticsearch client contribution and the Hibernate configuration for SQL.
2. **Document the Audit Router** — new `audit-router` child page describing the routing pipeline, the new `routes` extension point (`backend`, `predicate`, `event`, route inheritance with `copy`), the built-in `CategoryLogEntryPredicate` and a worked example routing a custom business event to a secondary OpenSearch backend. Backward compatibility with the legacy `event` extension point is documented.
3. **Document the Blue/Green Audit migration** — new `copy-audit-backend` child page covering the `audit` scroll, the `copyAudit` Bulk Action and the Management REST endpoints, plus the typical Blue/Green migration workflow. The upcoming uninterrupted Audit Purge ([NXENG-241](https://hyland.atlassian.net/browse/NXENG-241)) is mentioned for context.
4. **Refresh main Audit page for the 2025 redesign** — new architecture pipeline (`StreamAuditEventListener` → `audit/audit` stream → `auditWriter` → `AuditRouter` → backends), promotion of `AuditService` / `AuditBackend` / `AuditRouter` as the primary services, light Router and Blue/Green sections linking to the new child pages, rewrite of the Extending section around `routes` (recommended) with `event` kept as deprecated/backward-compatible, removal of the obsolete `queues` and `hibernate` sections (Hibernate moved to the SQL backend page).

Anchors referenced by other pages (`#extendedinfo`, `#extended-info`, `#querying-the-audit-data-store`) are preserved.

## Cross-references

- REST API documentation companion PR: nuxeo/doc.nuxeo.com-rest-api#82 (already links to the new `audit-router` slug).
- The directory-storage backend is intentionally not documented (it is not user-facing on the main page today).