### PR TITLE
DOCU-95459 Remove header from documentation notice

### DIFF
--- a/src/documentation-notice.md
+++ b/src/documentation-notice.md
@@ -14,8 +14,6 @@ history:
     - 
 ---
 
-# Documentation Notice
-
 The information and software described in this document are furnished only under a separate agreement and may only be used or copied according to the terms of such agreement. It is against the law to copy the software except as specifically allowed in such agreement. Complying with all applicable copyright laws is the responsibility of the user. Without limiting the rights under copyright law, no part of this document may be reproduced, stored in or introduced into a retrieval system, or transmitted in any form or by any means (electronic, mechanical, photocopying, recording, or otherwise), or for any purpose, without the express written permission of Hyland Software, Inc. and/or one of its affiliates.
 
 Hyland, OnBase, Alfresco, Nuxeo, Content Innovation Cloud, and other product or brand names are registered and/or unregistered trademarks of Hyland Software, Inc. and its affiliates in the United States and other countries. All other trademarks, service marks, trade names and products of other companies are the property of their respective owners.


### PR DESCRIPTION
Removed the header for the documentation notice section.