### PR TITLE
NXDOC-2967: Document tuning of full repository re-indexing

### DIFF
--- a/src/nxdoc/nuxeo-server/administration/configuration-parameters-index-nuxeoconf.md
+++ b/src/nxdoc/nuxeo-server/administration/configuration-parameters-index-nuxeoconf.md
@@ -2078,6 +2078,126 @@ Limit the binary fulltext size during indexing to improve search engine performa
 
 * * *
 
+#### `nuxeo.search.indexing.enabled`
+
+Master switch enabling the search indexing subsystem: the `ongoingIndexing` stream processor and the `bulk/indexing` and `bulk/indexingBackground` bulk actions. Set to `false` to disable all search indexing.
+
+**Since LTS 2025**
+
+**Default Value**
+
+`true`
+
+* * *
+
+#### `nuxeo.search.indexing.defaultPartitions`
+
+Number of partitions of the `source/indexing` domain event stream, into which indexing commands are produced when documents are created, updated or deleted. Caps the maximum parallelism of the ongoing indexing across the cluster.
+
+**Since LTS 2025**
+
+**Default Value**
+
+`4`
+
+* * *
+
+#### `nuxeo.search.stream.indexing.defaultConcurrency`
+
+Concurrency of the `ongoingIndexing` stream processor on each Nuxeo node. This processor performs the near real time (synchronous) ongoing indexing of document changes by consuming the `source/indexing` stream.
+
+**Since LTS 2025**
+
+**Default Value**
+
+`4`
+
+* * *
+
+#### `nuxeo.search.stream.indexing.defaultPartitions`
+
+Number of partitions of the `ongoingIndexing` stream processor. Caps the maximum parallelism of the near real time (synchronous) ongoing indexing across the cluster.
+
+**Since LTS 2025**
+
+**Default Value**
+
+`12`
+
+* * *
+
+#### `nuxeo.search.stream.indexing.batch.size`
+
+Maximum number of indexing records per batch flushed to the search engine by the `ongoingIndexing` processor (near real time synchronous ongoing indexing).
+
+**Since LTS 2025**
+
+**Default Value**
+
+`20`
+
+* * *
+
+#### `nuxeo.search.stream.indexing.batch.threshold`
+
+Maximum time to wait before flushing a non-full batch from the `ongoingIndexing` processor (near real time synchronous ongoing indexing).
+
+**Since LTS 2025**
+
+**Default Value**
+
+`250ms`
+
+* * *
+
+#### `nuxeo.search.stream.indexingAsync.defaultConcurrency`
+
+Concurrency of the `indexing` stream processor (bulk action `bulk/indexing`). This bulk action performs the asynchronous ongoing indexing: fan-out of recursive indexing commands (subtree updates, ACL changes, move/copy of containers) and asynchronous bulk indexing commands.
+
+**Since LTS 2025**
+
+**Default Value**
+
+`4`
+
+* * *
+
+#### `nuxeo.search.stream.indexingAsync.defaultPartitions`
+
+Number of partitions of the `indexing` stream processor (bulk action `bulk/indexing`). Caps the maximum parallelism of the asynchronous ongoing indexing across the cluster.
+
+**Since LTS 2025**
+
+**Default Value**
+
+`8`
+
+* * *
+
+#### `nuxeo.search.stream.reindexing.defaultConcurrency`
+
+Concurrency of the `indexingBackground` stream processor (bulk action `bulk/indexingBackground`) used by full repository re-indexing.
+
+**Since LTS 2025**
+
+**Default Value**
+
+`4`
+
+* * *
+
+#### `nuxeo.search.stream.reindexing.defaultPartitions`
+
+Number of partitions of the `indexingBackground` stream processor. Caps the maximum parallelism of a full re-index across the cluster.
+
+**Since LTS 2025**
+
+**Default Value**
+
+`8`
+
+* * *
+
 <div class="row" data-equalizer data-equalize-on="medium">
 <div class="column medium-6">
 

--- a/src/nxdoc/nuxeo-server/administration/search-setup.md
+++ b/src/nxdoc/nuxeo-server/administration/search-setup.md
@@ -590,6 +590,15 @@ Simply don't install any `nuxeo-search-client-*` or `nuxeo-audit-*` package.
 
 ## Rebuilding the Repository Index{{> anchor 'reindex'}}
 
+The repository re-indexing runs on a dedicated [Bulk Action]({{page page='bulk-action-framework'}}) named `indexingBackground` with its own stream processor. As described in [Search Indexing Logic]({{page page='elasticsearch-indexing-logic'}}#re-indexing-logic), this isolates the full re-index from the ongoing indexing pipeline, so ongoing document changes keep being indexed in near real time during a re-index.
+
+The throughput of a full re-index can be tuned independently from the ongoing indexing by adjusting two properties in `nuxeo.conf`:
+
+- `nuxeo.search.stream.reindexing.defaultConcurrency` (default: `4`) — the number of threads used by the re-indexing stream processor on each Nuxeo node.
+- `nuxeo.search.stream.reindexing.defaultPartitions` (default: `8`) — the number of stream partitions for the re-indexing action. Caps the maximum parallelism of a full re-index across the cluster.
+
+Increase these values to speed up a full re-index on large repositories, at the cost of additional load on the search cluster and on the Nuxeo workers. See [Configuration Parameters Index]({{page page='configuration-parameters-index-nuxeoconf'}}) for the complete list of related properties.
+
 If you need to reindex the whole repository, you have different possibilities:
 
 ### Re-index Repository with interruption of service{{> anchor 'reindexing-bulk'}}

--- a/src/nxdoc/nuxeo-server/data-store/indexing-and-query/elasticsearch-indexing-logic.md
+++ b/src/nxdoc/nuxeo-server/data-store/indexing-and-query/elasticsearch-indexing-logic.md
@@ -194,11 +194,11 @@ Watch the related courses on Hyland University:</br>
 ![]({{file name='university-search.png' page='nxdoc/university'}} ?w=450,border=true)
 {{/callout}}
 
-## Indexing
+## Ongoing Indexing
 
-The indexing process involves stacking indexing commands when manipulating sessions to create, update, or delete documents. These commands are then emitted as indexing domain events into a `source/indexing` stream when the transaction is committed.
+The ongoing indexing process involves stacking indexing commands when manipulating sessions to create, update, or delete documents. These commands are then emitted as indexing domain events into a `source/indexing` stream when the transaction is committed.
 
-There are two indexing processors:
+There are two ongoing indexing processors:
 - A **Synchronous processor**:
   When a UI request is involved, some indexing commands are marked as synchronous. After transaction commit, the thread waits for these specific commands to be processed by the synchronous processor before returning.
   This way the next UI request is able to search updated documents, giving a real time indexing appearance.
@@ -208,7 +208,17 @@ There are two indexing processors:
 
 When indexing a document, the Nuxeo Platform sends a JSON representation to be indexed. A creation or update command submits the complete document. For OpenSearch/Elasticsearch engines, the JSON document can be viewed in the `_source` field. It is possible to override the default JSON writer (`DefaultIndexingJsonWriter`).
 
-Note that this is a new indexing logic implemented in LTS 2025, which no longer relies on WorkManager.
+Note that this is a new ongoing indexing logic implemented in LTS 2025, which no longer relies on WorkManager.
+
+## Re-indexing Logic
+
+A full repository re-index is run as a dedicated [Bulk Action]({{page page='bulk-action-framework'}}) named `indexingBackground` that consumes its own stream `bulk/indexingBackground`. This stream and its computation are fully isolated from the ongoing indexing pipeline described above:
+
+- Ongoing indexing keeps running on the `source/indexing` stream (synchronous and asynchronous processors): documents created, updated or deleted while a full re-index is in progress are still indexed in near real time and remain searchable.
+- The re-index action scrolls the repository, rebuilds the JSON representation of each document and submits it to the search engine without going through `source/indexing`. It therefore does not compete with the ongoing indexing throughput and does not delay the visibility of fresh changes.
+- The re-index stream processor can be sized independently from the ongoing indexing pipeline. See [Search Setup]({{page page='search-setup'}}#reindex) for the tuning procedure.
+
+The same `indexingBackground` action is used both for the blocking "re-index with interruption of service" procedure and for the blue/green "re-index without interruption of service" procedure available since LTS 2025.11.
 
 ## Searching and Limitations
 


### PR DESCRIPTION
## NXDOC-2967: Document tuning of full repository re-indexing

Documents how to tune full repository re-indexing in LTS 2025, including the dedicated `indexingBackground` bulk action stream that runs isolated from the ongoing indexing pipeline.

### Changes

- **`elasticsearch-indexing-logic.md`**: Renamed `## Indexing` to `## Ongoing Indexing` for consistent naming. Added new `## Re-indexing Logic` section explaining the dedicated `indexingBackground` bulk action and stream isolation.
- **`search-setup.md`**: Added a tuning paragraph under `## Rebuilding the Repository Index` documenting `nuxeo.search.stream.reindexing.defaultConcurrency` and `nuxeo.search.stream.reindexing.defaultPartitions` with guidance for cluster sizing.
- **`configuration-parameters-index-nuxeoconf.md`**: Added 9 properties:
  - `nuxeo.search.indexing.enabled`
  - `nuxeo.search.indexing.defaultPartitions`
  - `nuxeo.search.stream.indexing.defaultConcurrency`
  - `nuxeo.search.stream.indexing.defaultPartitions`
  - `nuxeo.search.stream.indexing.batch.size`
  - `nuxeo.search.stream.indexing.batch.threshold`
  - `nuxeo.search.stream.indexingAsync.defaultConcurrency`
  - `nuxeo.search.stream.indexingAsync.defaultPartitions`
  - `nuxeo.search.stream.reindexing.defaultConcurrency`
  - `nuxeo.search.stream.reindexing.defaultPartitions`

Defaults verified against `nuxeo-2025/server/nuxeo-nxr-server/src/main/resources/templates/common-base/nuxeo.defaults` and `nuxeo-2025/modules/core/nuxeo-core-search/src/main/resources/OSGI-INF/indexing-stream-processor-contrib.xml`.

JIRA: [NXDOC-2967](https://hyland.atlassian.net/browse/NXDOC-2967)