### PR TITLE
[SKILL-TEST · will be closed] Web UI 2025.18.0 release notes (NXDOC-2991)

### DIFF
--- a/src/nxdoc/web-ui/web-ui-release-notes.md
+++ b/src/nxdoc/web-ui/web-ui-release-notes.md
@@ -3,7 +3,7 @@ title: Web UI Release Notes
 description: Discover changes brought in our recent Nuxeo Web UI updates.
 review:
   comment: ''
-  date: '2026-07-03'
+  date: '2026-07-31'
   status: ok
 toc: true
 labels:
@@ -19,14 +19,15 @@ This page mentions what's new. Refer to the [upgrade notes]({{page page='web-ui-
 
 ## Recently Released Changes
 
-{{{multiexcerpt 'web-ui-updates' page='web-ui-release-notes-2025-17-0'}}}
+{{{multiexcerpt 'web-ui-updates' page='web-ui-release-notes-2025-18-0'}}}
 
 ## Previous Release Notes
 
-<!-- | [Web UI 2025.17.0]({{page page='web-ui-release-notes-2025-17-0'}}) |Enhancements, Bug Fixes, Accessibility Improvements, and Performance, Reliability & Quality Improvements.| -->
+<!-- | [Web UI 2025.18.0]({{page page='web-ui-release-notes-2025-18-0'}}) |User Experience Improvements, Accessibility Improvements, Administration & Directory Management, Workflow & Document Management and Platform & Build Improvements.| -->
 
 | Version                                                                      | Summary                                                                              |
 | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| [Web UI 2025.17.0]({{page page='web-ui-release-notes-2025-17-0'}}) |Enhancements, Bug Fixes, Accessibility Improvements, and Performance, Reliability & Quality Improvements.|
 | [Web UI 2025.16.0]({{page page='web-ui-release-notes-2025-16-0'}}) |Enhancements, Bug Fixes, Security & Quality Improvements, and Engineering & Reliability Improvements.|
 || [Web UI 2025.15.0]({{page page='web-ui-release-notes-2025-15-0'}}) | Accessibility fixes, usability, and platform reliability improvements. |
 | [Web UI 2025.14.0]({{page page='web-ui-release-notes-2025-14-0'}}) | Preservation of user preferences. Enhancements. Security Improvements. Bug Fixes. Includes support ticket resolutions|

--- a/src/nxdoc/web-ui/web-ui-release-notes/web-ui-release-notes-2025-17-0.md
+++ b/src/nxdoc/web-ui/web-ui-release-notes/web-ui-release-notes-2025-17-0.md
@@ -3,12 +3,12 @@ title: Version 2025.17.0
 description: Discover what's new in Web UI 2025.17.0.
 review:
   comment: ''
-  date: '2026-07-03'
+  date: '2026-07-31'
   status: ok
 toc: true
 labels:
 tree_item_index: 984
-hidden: true
+hidden: false
 ---
 
 {{{multiexcerpt 'matching-notes' page='web-ui-release-notes'}}}

--- a/src/nxdoc/web-ui/web-ui-release-notes/web-ui-release-notes-2025-18-0.md
+++ b/src/nxdoc/web-ui/web-ui-release-notes/web-ui-release-notes-2025-18-0.md
@@ -1,0 +1,64 @@
+---
+title: Version 2025.18.0
+description: Discover what's new in Web UI 2025.18.0.
+review:
+  comment: ''
+  date: '2026-07-31'
+  status: ok
+toc: true
+labels:
+tree_item_index: 983
+hidden: true
+---
+
+{{{multiexcerpt 'matching-notes' page='web-ui-release-notes'}}}
+
+{{! multiexcerpt name='web-ui-updates'}}
+
+## What’s New in Web UI for LTS 2025 (Version 2025.18.0)
+
+**User Experience Improvements**
+- ***Improved document display after workflow completion:***
+    - After completing a workflow task and refreshing the page, Web UI now correctly displays the associated document instead of the completed workflow task.
+- ***Improved comment author display:***
+    - Comments now display the author's full name instead of their username, providing a more user-friendly experience and aligning with the behaviour found in the legacy JSF UI.
+- ***Improved avatar rendering:***
+    - User avatars now display only the first and last name initials, preventing initials from overflowing the avatar circle for users with multi-part names.
+- ***Improved Recent Documents reliability:***
+    - Fixed an issue where corrupted local storage data could prevent navigation from the Recent Documents list. The application now automatically recovers from invalid stored values.
+- ***Improved document list readability:***
+    - Restored the expected width of the Document Title column in List View, improving readability when multiple metadata columns are displayed.
+- ***Improved placeholder configuration for the Date picker:***
+    - Administrators can now control the visibility of placeholders through a configurable nuxeo.conf property. The application also provides the correct validation message when an invalid format is used.
+
+**Accessibility Improvements**
+- ***Enhanced Grid View accessibility:***
+    - Improved Grid View accessibility by eliminating redundant adjacent links that could cause duplicate announcements by screen readers during keyboard navigation.
+- ***Improved screen reader support in the Permissions screen:***
+    - Repeated buttons now expose unique accessible names, making them easier to identify and use with screen readers.
+- ***Improved iframe accessibility in the Document Viewer:***
+    - Added missing title attributes to inline frames (iframes) to improve screen reader compatibility and support WCAG compliance requirements.
+- ***Improved pagination accessibility:***
+    - Pagination controls now provide clearer context and navigation semantics for screen reader users, improving accessibility when navigating large result sets.
+
+**Administration & Directory Management**
+- ***Improved group membership management:***
+    - Group member listings now identify users that no longer exist in the directory. These entries are clearly marked as not found and can be removed directly from the group.
+- ***Improved user detail synchronization:***
+    - When a user's attributes are updated, the Group view now immediately reflects the latest user information without requiring additional actions.
+
+**Workflow & Document Management**
+- ***Improved WOPI action availability:***
+    - Fixed an issue that could cause the WOPI action button to disappear after a page refresh. The required metadata is now loaded correctly during the initial request, ensuring the action remains available when applicable.
+- ***Improved collection and document navigation reliability:***
+    - Resolved a spurious AbortError that could appear in browser consoles when document listings were cancelled due to rapid navigation, filtering, sorting, or refresh operations.
+
+**Platform & Build Improvements**
+- ***Migrated unit testing framework:***
+    - Migrated the Elements Repository unit test framework from Karma to Web Test Runner, providing a more modern and maintainable testing platform.
+- ***Improved build reproducibility and security:***
+    - Locked JavaScript dependencies to verified versions and adopted deterministic dependency installation processes to improve supply-chain security and ensure consistent builds across environments.
+
+<br/>
+
+{{! /multiexcerpt}}

--- a/src/nxdoc/web-ui/web-ui-release-notes/web-ui-release-notes-2025-18-0.md
+++ b/src/nxdoc/web-ui/web-ui-release-notes/web-ui-release-notes-2025-18-0.md
@@ -18,46 +18,46 @@ hidden: true
 ## What’s New in Web UI for LTS 2025 (Version 2025.18.0)
 
 **User Experience Improvements**
-- ***Improved document display after workflow completion:***
-    - After completing a workflow task and refreshing the page, Web UI now correctly displays the associated document instead of the completed workflow task.
+- ***Improved navigation after workflow task completion:***
+    - After completing a workflow task and refreshing the page, Web UI now displays the associated document instead of the completed task.
 - ***Improved comment author display:***
-    - Comments now display the author's full name instead of their username, providing a more user-friendly experience and aligning with the behaviour found in the legacy JSF UI.
-- ***Improved avatar rendering:***
-    - User avatars now display only the first and last name initials, preventing initials from overflowing the avatar circle for users with multi-part names.
-- ***Improved Recent Documents reliability:***
-    - Fixed an issue where corrupted local storage data could prevent navigation from the Recent Documents list. The application now automatically recovers from invalid stored values.
-- ***Improved document list readability:***
-    - Restored the expected width of the Document Title column in List View, improving readability when multiple metadata columns are displayed.
-- ***Improved placeholder configuration for the Date picker:***
-    - Administrators can now control the visibility of placeholders through a configurable nuxeo.conf property. The application also provides the correct validation message when an invalid format is used.
+    - Comment authors now show their full name instead of their username, restoring parity with the legacy JSF UI.
+- ***Improved avatar initials for multi-part names:***
+    - User avatars now show only the first and last name initials, so initials no longer overflow the avatar circle for users with multi-part names.
+- ***Improved Recent Documents resilience:***
+    - Recent Documents now recovers automatically from a corrupted or empty local-storage value that previously caused an error and blocked navigation.
+- ***Restored the Title column width in List View:***
+    - Fixed a regression affecting the document Title column width in List View, improving readability when several metadata columns are shown.
+- ***Improved Date picker placeholder and validation:***
+    - Placeholder visibility for the Date picker can now be controlled through a nuxeo.conf property, and an invalid date format now shows the correct error message.
 
 **Accessibility Improvements**
-- ***Enhanced Grid View accessibility:***
-    - Improved Grid View accessibility by eliminating redundant adjacent links that could cause duplicate announcements by screen readers during keyboard navigation.
-- ***Improved screen reader support in the Permissions screen:***
-    - Repeated buttons now expose unique accessible names, making them easier to identify and use with screen readers.
-- ***Improved iframe accessibility in the Document Viewer:***
-    - Added missing title attributes to inline frames (iframes) to improve screen reader compatibility and support WCAG compliance requirements.
+- ***Removed duplicate screen reader announcements in Grid View:***
+    - Adjacent links in Grid View no longer cause screen readers to announce the same item twice during keyboard navigation.
+- ***Unique accessible names for repeated buttons:***
+    - Repeated buttons now expose unique names to screen readers, making them easier to tell apart.
+- ***Added titles to inline frames:***
+    - Inline frames (iframes) now include title attributes, improving screen reader support and WCAG compliance.
 - ***Improved pagination accessibility:***
-    - Pagination controls now provide clearer context and navigation semantics for screen reader users, improving accessibility when navigating large result sets.
+    - Pagination controls now provide clearer navigation semantics and context for screen reader users when results span multiple pages.
 
 **Administration & Directory Management**
-- ***Improved group membership management:***
-    - Group member listings now identify users that no longer exist in the directory. These entries are clearly marked as not found and can be removed directly from the group.
-- ***Improved user detail synchronization:***
-    - When a user's attributes are updated, the Group view now immediately reflects the latest user information without requiring additional actions.
+- ***Improved handling of removed users in group listings:***
+    - Group member listings now surface users that no longer exist in the directory, flag them as not found, and allow them to be removed from the group.
+- ***Refreshed user details in the Group view:***
+    - Editing a user's attributes now immediately refreshes the user details shown in the Group view.
 
 **Workflow & Document Management**
-- ***Improved WOPI action availability:***
-    - Fixed an issue that could cause the WOPI action button to disappear after a page refresh. The required metadata is now loaded correctly during the initial request, ensuring the action remains available when applicable.
-- ***Improved collection and document navigation reliability:***
-    - Resolved a spurious AbortError that could appear in browser consoles when document listings were cancelled due to rapid navigation, filtering, sorting, or refresh operations.
+- ***Kept the WOPI action available after refresh:***
+    - The WOPI action button no longer disappears after a page refresh; the data it depends on is now loaded during the initial request.
+- ***Silenced a spurious AbortError on cancelled listings:***
+    - A harmless AbortError no longer appears in the browser console when a document listing is cancelled by rapid navigation, filtering, sorting, or refreshing.
 
 **Platform & Build Improvements**
-- ***Migrated unit testing framework:***
-    - Migrated the Elements Repository unit test framework from Karma to Web Test Runner, providing a more modern and maintainable testing platform.
+- ***Migrated the unit test framework:***
+    - The Elements unit test framework has moved from Karma to Web Test Runner, providing a more modern and maintainable testing platform.
 - ***Improved build reproducibility and security:***
-    - Locked JavaScript dependencies to verified versions and adopted deterministic dependency installation processes to improve supply-chain security and ensure consistent builds across environments.
+    - JavaScript dependencies are now locked to verified versions with deterministic CI installs, improving supply-chain security and keeping builds consistent across environments.
 
 <br/>
 


### PR DESCRIPTION
> ⚠️ **Automated skill-test PR — do not review/merge. Will be closed shortly.**
> Validates the `web-ui-release-notes` generator against the real 2025.18.0 Jira bucket. The real release-notes PR is #2792.

## Source
- fixVersion `2025.18.0` across **WEBUI + ELEMENTS** (23 tickets); notes written from each ticket's **Release Notes Summary** field, verified + polished to house style.

## Included (16 items) / Excluded (4)
- Excluded: `ELEMENTS-1980` / `WEBUI-2126` (alpha-build workflow — internal), `WEBUI-2041` (CI preview env), `WEBUI-2180` (not shipped — *In Review*).
- Security: consolidated into one Platform & Build line.

## Files
- new `web-ui-release-notes-2025-18-0.md` (hidden, tree_item_index 983)
- `web-ui-release-notes-2025-17-0.md` → hidden:false + date bump
- landing page: date, excerpt pointer, previous summary → table, comment → 2025.18.0